### PR TITLE
Enable travis for repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
     - cd "$DOCKER" && make update
 
 script:
-    - cd "$DOCKER" && make build && make test
+    - make build && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ services:
 
 install:
     - sudo apt-get install -qyy debootstrap
-    - make update
+    - sudo ln -s /usr/share/debootstrap/scripts/sid /usr/share/debootstrap/scripts/stretch
+    - make -j4 update
 
 script:
     - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,20 @@ sudo: required
 services:
     - docker
 
+matrix:
+  fast_finish: true
+  include:
+    - env: DOCKER="alpine"
+    - env: DOCKER="arch"
+    - env: DOCKER="ubuntu-trusty-x86"
+    - env: DOCKER="ubuntu-xenial-amd64"
+    - env: DOCKER="ubuntu-precise-amd64"
+    - env: DOCKER="debian-stretch-x86"
+
 install:
     - sudo apt-get install -qyy debootstrap
     - sudo ln -s /usr/share/debootstrap/scripts/sid /usr/share/debootstrap/scripts/stretch
-    - make -j4 update
+    - cd "$DOCKER" && make update
 
 script:
-    - make build
-    - make test
+    - cd "$DOCKER" && make build && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ services:
     - docker
 
 install:
-    - git submodule init
-    - git submodule update
+    - sudo apt-get install -qyy debootstrap
     - make update
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+notifications:
+    irc: "chat.freenote.net#pil"
+
+dist: trusty
+sudo: required
+services:
+    - docker
+
+install:
+    - git submodule init
+    - git submodule update
+    - make update
+
+script:
+    - make build
+    - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - env: DOCKER="debian-stretch-x86"
 
 install:
-    - sudo apt-get install -qyy debootstrap
+    - sudo apt-get update && sudo apt-get install -qyy debootstrap
     - sudo ln -s /usr/share/debootstrap/scripts/sid /usr/share/debootstrap/scripts/stretch
     - cd "$DOCKER" && make update
 

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -7,7 +7,7 @@ RUN pacman -Sy --noconfirm \
 	        python2 python  \
  			python2-virtualenv \
  			python-virtualenv \	
-	   		gcc make git sudo \
+			gcc make git sudo wget \
 			python2-setuptools \
  			python-setuptools \
  			extra/libjpeg-turbo \
@@ -26,7 +26,7 @@ RUN pacman -Sy --noconfirm \
 
 
 ADD depends /depends
-RUN	cd /depends &&  ./install_imagequant.sh
+RUN	cd /depends && ./install_imagequant.sh
 
 RUN /sbin/useradd -m -U -u 1000 pillow && \
 	virtualenv2 --system-site-packages /vpy && \


### PR DESCRIPTION
Enable travis build & test of all docker images.

This is blocked on the QT4/5 tests being fixed here: https://github.com/python-pillow/Pillow/pull/2394

TODO when satisfied -- push to deploy. 