### PR TITLE
ubuntu-precise-amd64: Upgrade pip, setuptools and wheel

### DIFF
--- a/ubuntu-precise-amd64/Dockerfile
+++ b/ubuntu-precise-amd64/Dockerfile
@@ -1,20 +1,22 @@
 FROM ubuntu:precise
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y \
-	install sudo xvfb \
-	git wget python-virtualenv python-numpy python-scipy netpbm \
-	python-qt4 ghostscript libffi-dev libjpeg-turbo-progs \
-	python-dev python-setuptools \
+    install sudo xvfb \
+    git wget python-virtualenv python-numpy python-scipy netpbm \
+    python-qt4 ghostscript libffi-dev libjpeg-turbo-progs \
+    python-dev python-setuptools \
     cmake make \
-	libtiff4-dev libjpeg8-dev zlib1g-dev \
+    libtiff4-dev libjpeg8-dev zlib1g-dev \
     libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev \
     python-tk
 
 RUN useradd pillow && addgroup pillow sudo
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-	/vpy/bin/pip install nose cffi olefile && \
-	chown -R pillow:pillow /vpy
+    /vpy/bin/pip install -U pip --index-url=https://pypi.python.org/simple/ && \
+    /vpy/bin/pip install -U setuptools wheel && \
+    /vpy/bin/pip install nose cffi olefile && \
+    chown -R pillow:pillow /vpy
 
 ADD depends /depends
 RUN	cd /depends && ./install_openjpeg.sh && ./install_imagequant.sh


### PR DESCRIPTION
master is failing for ubuntu-precise-amd64:

```
Downloading/unpacking nose
  Cannot fetch index base URL http://pypi.python.org/simple/
  Could not find any downloads that satisfy the requirement nose
No distributions at all found for nose
Storing complete log in /root/.pip/pip.log
The command '/bin/sh -c virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && 	/vpy/bin/pip install nose cffi olefile && 	chown -R pillow:pillow /vpy' returned a non-zero code: 1
make: *** [build] Error 1
```

https://travis-ci.org/python-pillow/docker-images/jobs/297614198#L1662

This is because it has ancient pip 1.1 (released in 2012) so upgrade it first (latest is now 9.0.1), and then upgrade setuptools and wheel for good measure.

(Also tabs to spaces.)