### PR TITLE
Centos-7 Docker Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - env: DOCKER="arch"
     - env: DOCKER="amazon-amd64"
     - env: DOCKER="centos-6-amd64"
+	- env: DOCKER="centos-7-amd64"	
     - env: DOCKER="fedora-24-amd64"
     - env: DOCKER="fedora-26-amd64"
     - env: DOCKER="ubuntu-trusty-x86"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - env: DOCKER="arch"
     - env: DOCKER="amazon-amd64"
     - env: DOCKER="centos-6-amd64"
-	- env: DOCKER="centos-7-amd64"	
+    - env: DOCKER="centos-7-amd64"	
     - env: DOCKER="fedora-24-amd64"
     - env: DOCKER="fedora-26-amd64"
     - env: DOCKER="ubuntu-trusty-x86"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 
-TARGETS = alpine arch amazon-amd64 ubuntu-precise-amd64 ubuntu-trusty-x86 ubuntu-xenial-amd64 debian-stretch-x86 fedora-24-amd64 fedora-26-amd64 centos-6-amd64
+TARGETS = alpine arch amazon-amd64 ubuntu-precise-amd64 ubuntu-trusty-x86 ubuntu-xenial-amd64 debian-stretch-x86 fedora-24-amd64 fedora-26-amd64 centos-6-amd64 centos-7-amd64
 
 BUILDDIRS = $(TARGETS:%=build-%)
 PUSHDIRS = $(TARGETS:%=push-%)

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:7
+
+run yum install -y epel-release centos-release-scl
+
+run yum install -y  python27 python-virtualenv \
+    gcc xorg-x11-server-Xvfb make which ghostscript sudo \
+    libtiff-devel libjpeg-devel zlib-devel freetype-devel \
+    lcms2-devel libwebp-devel openjpeg2-devel tkinter \
+    tcl-devel tk-devel libffi-devel libimagequant-devel \
+	libraqm-devel
+
+RUN useradd --uid 1000 pillow
+
+RUN bash -c "source /opt/rh/python27/enable && \
+    /opt/rh/python27/root/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
+    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    cat /opt/rh/python27/enable /vpy/bin/activate > /vpy/bin/activate2.7 && \
+    mv  /vpy/bin/activate2.7  /vpy/bin/activate && \
+    chown -R pillow:pillow /vpy "
+
+RUN echo "#!/bin/bash" >> /test && \
+    echo "source /vpy/bin/activate && cd /Pillow " >> test && \
+    echo "export DISPLAY=:99.0" >> test && \
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a python ./test-installed.py --processes=0 -v --with-coverage" >> test
+
+RUN chmod +x /test
+
+USER pillow
+CMD ["/test"]
+

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -7,7 +7,7 @@ run yum install -y  python27 python-virtualenv \
     libtiff-devel libjpeg-devel zlib-devel freetype-devel \
     lcms2-devel libwebp-devel openjpeg2-devel tkinter \
     tcl-devel tk-devel libffi-devel libimagequant-devel \
-	libraqm-devel
+    libraqm-devel
 
 RUN useradd --uid 1000 pillow
 

--- a/centos-7-amd64/Makefile
+++ b/centos-7-amd64/Makefile
@@ -1,0 +1,1 @@
+../Makefile.sub

--- a/centos-7-amd64/README.md
+++ b/centos-7-amd64/README.md
@@ -1,0 +1,5 @@
+# Centos 7 Image
+
+##Issues
+
+- TK isn't recognized

--- a/centos-7-amd64/update.sh
+++ b/centos-7-amd64/update.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-docker pull centos:6
+docker pull centos:7
 

--- a/centos-7-amd64/update.sh
+++ b/centos-7-amd64/update.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker pull centos:6
+


### PR DESCRIPTION
Docker test support for Centos 7.

Currently supports all features, except for Advanced WebP and TK. 

This is built off of the coverage branch, so coverage is installed. 