### PR TITLE
Drop CI support for EOL Ubuntu 12.04 Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
     - env: DOCKER="fedora-26-amd64"
     - env: DOCKER="ubuntu-trusty-x86"
     - env: DOCKER="ubuntu-xenial-amd64"
-    - env: DOCKER="ubuntu-precise-amd64"
     - env: DOCKER="debian-stretch-x86"
 
 install:


### PR DESCRIPTION
Analogue of https://github.com/python-pillow/Pillow/pull/2854.

Like https://github.com/python-pillow/docker-images/pull/17, I've left the directory here in case it's useful documentation. If not, let's remove it too.