### PR TITLE
 Test with pytest instead of nose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 depends
+.idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "Pillow"]
 	path = Pillow
-	url = https://github.com/python-pillow/Pillow.git
+	url = https://github.com/hugovk/Pillow.git
+	branch = pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ matrix:
   fast_finish: true
   include:
     - env: DOCKER="alpine"
-    - env: DOCKER="arch"
     - env: DOCKER="amazon-1-amd64"
     - env: DOCKER="amazon-2-amd64"
+    - env: DOCKER="arch"
     - env: DOCKER="centos-6-amd64"
-    - env: DOCKER="centos-7-amd64"	
+    - env: DOCKER="centos-7-amd64"
     - env: DOCKER="fedora-26-amd64"
     - env: DOCKER="fedora-27-amd64"
     - env: DOCKER="ubuntu-trusty-x86"

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -34,12 +34,12 @@ RUN cd /depends && ./install_webp.sh && ./install_imagequant.sh && ./install_raq
 
 RUN /usr/sbin/adduser -D pillow && \
     pip install virtualenv && virtualenv /vpy && \
-    /vpy/bin/pip install nose olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy
 
 RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
-    echo "make clean && LIBRARY_PATH=/lib:/usr/lib make install-coverage && python test-installed.py -v --with-coverage" >> test
+    echo "make clean && LIBRARY_PATH=/lib:/usr/lib make install-coverage && pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/amazon-1-amd64/Dockerfile
+++ b/amazon-1-amd64/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
     echo "export DISPLAY=:99.0" >> test && \
     echo "export LD_LIBRARY_PATH=/usr/lib" >> test && \
-    echo "make clean && make install-coverage && pytest -vx --cov PIL --cov-report term Tests" >> test
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/amazon-1-amd64/Dockerfile
+++ b/amazon-1-amd64/Dockerfile
@@ -11,7 +11,7 @@ run yum install -y shadow-utils util-linux xorg-x11-xauth \
 RUN useradd --uid 1000 pillow
 
 RUN bash -c "/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy "
 
 ADD depends /depends
@@ -21,7 +21,7 @@ RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
     echo "export DISPLAY=:99.0" >> test && \
     echo "export LD_LIBRARY_PATH=/usr/lib" >> test && \
-    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a python ./test-installed.py -v --with-coverage" >> test
+    echo "make clean && make install-coverage && pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "/usr/bin/pip3 install virtualenv && \
     /usr/bin/python3 -mvirtualenv -p /usr/bin/python3 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy "
 
 ADD depends /depends
@@ -25,10 +25,7 @@ RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
     echo "export DISPLAY=:99.0" >> test && \
     echo "export LD_LIBRARY_PATH=/usr/lib" >> test && \
-    echo "make clean" >> test && \
-    echo 'CFLAGS="-coverage" python setup.py build_ext --inplace' >> test && \
-    echo "/usr/bin/xvfb-run -a coverage run --include="PIL/*" -m nose -vx Tests/test_*.py" >> test && \
-    echo 'coverage report' >> test
+    echo "make clean && make install-coverage && pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
     echo "export DISPLAY=:99.0" >> test && \
     echo "export LD_LIBRARY_PATH=/usr/lib" >> test && \
-    echo "make clean && make install-coverage && pytest -vx --cov PIL --cov-report term Tests" >> test
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -33,16 +33,16 @@ RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
 
 RUN /sbin/useradd -m -U -u 1000 pillow && \
     virtualenv2 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install nose cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy && \
     virtualenv --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy3/bin/pip install nose cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy3
 
 RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
     echo "make clean && make install-coverage " >> test && \
-    echo "QT_QPA_PLATFORM=offscreen /usr/bin/xvfb-run -a python test-installed.py -v --with-coverage" >> test
+    echo "QT_QPA_PLATFORM=offscreen /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/centos-6-amd64/Dockerfile
+++ b/centos-6-amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "source /opt/rh/python27/enable && \
     /opt/rh/python27/root/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
     cat /opt/rh/python27/enable /vpy/bin/activate > /vpy/bin/activate2.7 && \
     mv  /vpy/bin/activate2.7  /vpy/bin/activate && \
     chown -R pillow:pillow /vpy "
@@ -23,7 +23,7 @@ RUN bash -c "source /opt/rh/python27/enable && \
 RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
     echo "export DISPLAY=:99.0" >> test && \
-    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a python ./test-installed.py --processes=0 -v --with-coverage" >> test
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -13,7 +13,7 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "source /opt/rh/python27/enable && \
     /opt/rh/python27/root/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
     cat /opt/rh/python27/enable /vpy/bin/activate > /vpy/bin/activate2.7 && \
     mv  /vpy/bin/activate2.7  /vpy/bin/activate && \
     chown -R pillow:pillow /vpy "
@@ -21,7 +21,7 @@ RUN bash -c "source /opt/rh/python27/enable && \
 RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
     echo "export DISPLAY=:99.0" >> test && \
-    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a python ./test-installed.py --processes=0 -v --with-coverage" >> test
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/debian-stretch-x86/Dockerfile
+++ b/debian-stretch-x86/Dockerfile
@@ -46,7 +46,7 @@ RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends
@@ -55,7 +55,7 @@ RUN cd /depends && ./install_openjpeg.sh && ./install_imagequant.sh && ./install
 RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
     echo "export DISPLAY=:99.0" >> test && \
-    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a python ./test-installed.py -v --with-coverage" >> test
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/fedora-26-amd64/Dockerfile
+++ b/fedora-26-amd64/Dockerfile
@@ -12,12 +12,12 @@ RUN useradd pillow && \
     chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy
 
 RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
-    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a python ./test-installed.py -v --with-coverage" >> test
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/fedora-27-amd64/Dockerfile
+++ b/fedora-27-amd64/Dockerfile
@@ -12,12 +12,12 @@ RUN useradd pillow && \
     chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy
 
 RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
-    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a python ./test-installed.py -v --with-coverage" >> test
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/ubuntu-trusty-x86/Dockerfile
+++ b/ubuntu-trusty-x86/Dockerfile
@@ -46,7 +46,7 @@ RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends
@@ -55,7 +55,7 @@ RUN cd /depends && ./install_openjpeg.sh && ./install_imagequant.sh && ./install
 RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
     echo "export DISPLAY=:99.0" >> test && \
-    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a python ./test-installed.py -v --with-coverage" >> test
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 

--- a/ubuntu-xenial-amd64/Dockerfile
+++ b/ubuntu-xenial-amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends
@@ -23,7 +23,7 @@ RUN cd /depends && ./install_openjpeg.sh && ./install_imagequant.sh && ./install
 
 RUN echo "#!/bin/bash" >> /test && \
     echo "source /vpy/bin/activate && cd /Pillow " >> test && \
-    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a python ./test-installed.py -v --with-coverage" >> test
+    echo "make clean && make install-coverage && /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests" >> test
 
 RUN chmod +x /test
 


### PR DESCRIPTION
Note: The first commit switches the Pillow submodule to my pytest branch from https://github.com/python-pillow/Pillow/pull/2815 to be able to test with the pytest code there. 

Pre/post-merge, or with a cherry-pick, this needs switching back to upstream master.