### PR TITLE
Add :$(BRANCH) to all docker runs, add tar and make to amazon-2-amd64

### DIFF
--- a/Makefile.sub
+++ b/Makefile.sub
@@ -25,5 +25,5 @@ clean:
 	rm -r depends
 
 shell:
-	docker run --rm -it -v $(ROOT):/Pillow $(IMAGENAME) /bin/bash
+	docker run --rm -it -v $(ROOT):/Pillow $(IMAGENAME):$(BRANCH) /bin/bash
 

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -16,7 +16,7 @@ update:
 	./update.sh
 
 test:
-	docker run --rm -v $(ROOT):/Pillow $(IMAGENAME)
+	docker run --rm -v $(ROOT):/Pillow $(IMAGENAME):$(BRANCH)
 
 push:
 	docker push $(IMAGENAME):$(BRANCH)

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -9,7 +9,7 @@ run yum install -y shadow-utils util-linux xorg-x11-xauth \
     libtiff-devel libjpeg-devel zlib-devel freetype-devel \
     lcms2-devel libwebp-devel harfbuzz-devel fribidi-devel \
     libffi-devel \
-	pth-devel gcc-c++
+    pth-devel gcc-c++ tar
 
 RUN useradd --uid 1000 pillow
 

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -5,7 +5,7 @@ run amazon-linux-extras install python3
 run yum install -y shadow-utils util-linux xorg-x11-xauth \
     findutils which \
     python3-devel python3-test python3-tkinter python-virtualenv \
-    gcc xorg-x11-server-Xvfb ghostscript sudo wget cmake \
+    gcc xorg-x11-server-Xvfb ghostscript sudo wget cmake make \
     libtiff-devel libjpeg-devel zlib-devel freetype-devel \
     lcms2-devel libwebp-devel harfbuzz-devel fribidi-devel \
     libffi-devel \


### PR DESCRIPTION
All but Alpine have started failing due to not being able to find the Docker image.

This fixes that.

We use the branch name when building the image, but not when running. This now causes problems for all images except for Alpine

Before:

```
Successfully tagged amazon-1-amd64:HEAD
docker run --rm -v /home/travis/build/python-pillow/docker-images/Pillow:/Pillow  amazon-1-amd64
Unable to find image 'amazon-1-amd64:latest' locally
```
https://travis-ci.org/python-pillow/docker-images/jobs/361337420#L2140

After:
```
Successfully tagged amazon-1-amd64:HEAD
docker run --rm -v /home/travis/build/hugovk/docker-images/Pillow:/Pillow  amazon-1-amd64:HEAD
python setup.py clean
```

---

Also, amazon-2-amd64 was missing the `tar` and `make` commands. `yum install` them.