### PR TITLE
Arch: Add 'pacman -Sy glibc libidn'

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -25,7 +25,8 @@ RUN pacman -Sy --noconfirm \
             python-pyqt5  \
             pkg-config \
             extra/fribidi \
-            extra/harfbuzz
+            extra/harfbuzz \
+            glibc
 
 
 ADD depends /depends

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -26,7 +26,8 @@ RUN pacman -Sy --noconfirm \
             pkg-config \
             extra/fribidi \
             extra/harfbuzz \
-            glibc
+            glibc \
+            libidn
 
 
 ADD depends /depends


### PR DESCRIPTION
Fixes #32.

Needed for `gs` in `TestFileEps::test_bytesio_object`.