### PR TITLE
'sudo: required' no longer required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ notifications:
     irc: "chat.freenote.net#pil"
 
 dist: trusty
-sudo: required
 services:
     - docker
 


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration