### PR TITLE
Push master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   ; fi
 - make build && make test
 after_success:
-- if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then make push ; fi
+- if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then make push BRANCH=master; fi
 env:
   global:
   - secure: W+ko5Y7TKxxEnJxji3NmnkoT/lRPCA/U6+ahBBQUXRhgbf7A6mXVaGgyBrerY5FZF//XAPYdbOIrVHnkhtUSB2yC//kzHsxWKMU2Rax7b228yfYaeGPtIFJ4MTSszqhadgSFk6zyByMNkz6XoufuY5RVpfp/VMxVR6YcOGmjOUhom92nZ9T2NfVP3HF2RLOn2O5N5+IhqJcGOced5FMIOPkrQcXBiikN2aCUg0KdUrcqRaFiPJINQn/FEWxQN717oAlRY9TE8DaziBIEB/z6nZ7CXLGVitc2jLjd/4fW0KGBB68XIHZ2S3rQ7kkr3y/LhptgZiJiSv+R/rxDC6NrfKwmG16xtDQVbnab9/iskdJax9fuQBlpLcyo+UuXbRs8pTNduJGV46ooOAOfF+2KvjTwLvYk9K6ahpt4W9vjs/ro1fF2gyG5haK/2MAZxT1xkT2WlRZwpDhMgE+ZBznGDMma6fbOvoWGhk7bfKUxVisb+CYuySfvhbdkYem+kMdUfcRb8Qo6750aK/fQdh8Xg9t+yCE4jzdzBH6RbTTmvNGOGFHhShCWmLVXU5LiYNLpxWCahuD4OYMSkq6WdobPKNZxl0xry2gxWLhIAFxoZMqdb2MWjdbf/0BSP0Fe2AliLfgZIXKq6t4l69pNJF2y2WieI6jVfeVotXCS2urVT+c=


### PR DESCRIPTION
https://hub.docker.com/r/pythonpillow/alpine/tags shows that the 'HEAD' tag was updated at the time of the last merge to master. The 'master' tag was not.

https://travis-ci.org/python-pillow/docker-images/jobs/472971314#L5845 shows 'docker push  [secure]/alpine:HEAD', so this makes sense.

This PR changes it to push master instead. See https://travis-ci.org/radarhere/docker-images/jobs/473143155#L5841 for 'docker push  alpine:master'