### PR TITLE
Tag docker build as master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 script:
 - if [[ -n "$DOCKER_USERNAME" ]]; then docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   ; fi
-- make build && make test
+- make build BRANCH=master && make test BRANCH=master
 after_success:
 - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then make push BRANCH=master; fi
 env:


### PR DESCRIPTION
Sequel to #45, replacement for #46

The reason that ['tag does not exist'](https://github.com/python-pillow/docker-images/pull/45#issuecomment-450554834) was being shown as an error was that it was still being tagged as HEAD at https://travis-ci.org/python-pillow/docker-images/jobs/473545361#L2118

To demonstrate that this works, I created [a branch in this repository, and removed the constraint to only push for master](https://github.com/python-pillow/docker-images/compare/branch_test) - https://travis-ci.org/python-pillow/docker-images/jobs/473663859. 'master' is now updated on https://hub.docker.com/r/pythonpillow/alpine/tags