### PR TITLE
Update wget in arch

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -3,11 +3,13 @@
 
 FROM greyltc/archlinux
 
+RUN pacman -Syu --noconfirm \
+            wget
 RUN pacman -Sy --noconfirm \
             python2 python  \
             python2-virtualenv \
             python-virtualenv \
-            gcc make git sudo wget \
+            gcc make git sudo \
             python2-setuptools \
             python-setuptools \
             extra/libjpeg-turbo \


### PR DESCRIPTION
The arch job is failing in the latest cron build - https://travis-ci.org/python-pillow/docker-images/builds/480277041

This PR fixes it