### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/ubuntu-trusty-x86/Dockerfile
+++ b/ubuntu-trusty-x86/Dockerfile
@@ -47,10 +47,7 @@ RUN useradd pillow && addgroup pillow sudo && \
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    chown -R pillow:pillow /vpy && \
-    virtualenv -p /usr/bin/python3.4 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
-    chown -R pillow:pillow /vpy3
+    chown -R pillow:pillow /vpy
 
 ADD depends /depends
 RUN cd /depends && ./install_openjpeg.sh && ./install_imagequant.sh && ./install_raqm.sh

--- a/ubuntu-trusty-x86/test.sh
+++ b/ubuntu-trusty-x86/test.sh
@@ -5,9 +5,3 @@ export DISPLAY=:99.0
 make clean
 make install-coverage
 /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests
-
-source /vpy3/bin/activate
-cd /Pillow
-make clean
-make install-coverage
-/usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/3581.

This means that this Trusty Docker image is no longer testing Python 3.x.

I don't think we need to worry about upgrading 3.x, as Trusty is EOL in April and we're testing 3.5 and 3.6 with Trusty with the "native" CI builds in the main repo.
