### PR TITLE
Arch: Pin pytest for Python 3

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -38,7 +38,7 @@ RUN /sbin/useradd -m -U -u 1000 pillow && \
     /vpy/bin/pip install nose cffi olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy && \
     virtualenv --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install nose cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install nose cffi olefile pytest==4.1.1 pytest-cov && \
     chown -R pillow:pillow /vpy3
 
 USER pillow


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/3641.

Alternative to https://github.com/python-pillow/Pillow/pull/3654 and https://github.com/python-pillow/Pillow/pull/3649.

A Qt test fails for Python 3 on Arch when Pytest is upgraded from 4.1.1 to the next 4.2.0, or 4.2.1 or the latest latest 4.3.0.

Pinning allows it to pass.

(Tested by creating temporary `pin-pytest` branch which, for Arch only, uploads a Docker image with the pinning (https://github.com/python-pillow/docker-images/compare/pin-pytest) and making a test build with Arch using that branch: https://travis-ci.org/hugovk/Pillow/builds/495458877)
