### PR TITLE
Add numpy

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -34,10 +34,10 @@ RUN cd /depends && ./install_webp.sh && ./install_imagequant.sh && ./install_raq
 
 RUN /usr/sbin/adduser -D pillow && \
     pip install virtualenv && virtualenv /vpy && \
-    /vpy/bin/pip install olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p python3.6 /vpy3 && \
-    /vpy3/bin/pip install olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy3
 
 USER pillow

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -35,11 +35,11 @@ RUN cd /depends && ./install_webp.sh && ./install_imagequant.sh && ./install_raq
 RUN /usr/sbin/adduser -D pillow && \
     pip install virtualenv && virtualenv /vpy && \
     /vpy/bin/pip install olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p python3.6 /vpy3 && \
     /vpy3/bin/pip install olefile pytest pytest-cov && \
-    /vpy3/bin/pip install numpy --only-binary=:all: && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3
 
 USER pillow

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -34,10 +34,12 @@ RUN cd /depends && ./install_webp.sh && ./install_imagequant.sh && ./install_raq
 
 RUN /usr/sbin/adduser -D pillow && \
     pip install virtualenv && virtualenv /vpy && \
-    /vpy/bin/pip install numpy olefile pytest pytest-cov && \
+    /vpy/bin/pip install olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p python3.6 /vpy3 && \
-    /vpy3/bin/pip install numpy olefile pytest pytest-cov && \
+    /vpy3/bin/pip install olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy3
 
 USER pillow

--- a/amazon-1-amd64/Dockerfile
+++ b/amazon-1-amd64/Dockerfile
@@ -11,10 +11,12 @@ run yum install -y shadow-utils util-linux xorg-x11-xauth \
 RUN useradd --uid 1000 pillow
 
 RUN bash -c "/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi numpy olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy && \
     /usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi numpy olefile pytest pytest-cov && \
+    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy3"
 
 ADD depends /depends

--- a/amazon-1-amd64/Dockerfile
+++ b/amazon-1-amd64/Dockerfile
@@ -11,10 +11,10 @@ run yum install -y shadow-utils util-linux xorg-x11-xauth \
 RUN useradd --uid 1000 pillow
 
 RUN bash -c "/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi numpy olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy && \
     /usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install cffi numpy olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy3"
 
 ADD depends /depends

--- a/amazon-1-amd64/Dockerfile
+++ b/amazon-1-amd64/Dockerfile
@@ -12,11 +12,11 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy && \
     /usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy3/bin/pip install numpy --only-binary=:all: && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3"
 
 ADD depends /depends

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "/usr/bin/pip3 install virtualenv && \
     /usr/bin/python3 -mvirtualenv -p /usr/bin/python3 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy "
 
 ADD depends /depends

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "/usr/bin/pip3 install virtualenv && \
     /usr/bin/python3 -mvirtualenv -p /usr/bin/python3 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
     chown -R pillow:pillow /vpy "
 
 ADD depends /depends

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -16,7 +16,7 @@ RUN useradd --uid 1000 pillow
 RUN bash -c "/usr/bin/pip3 install virtualenv && \
     /usr/bin/python3 -mvirtualenv -p /usr/bin/python3 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy "
 
 ADD depends /depends

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -35,10 +35,10 @@ RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
 
 RUN /sbin/useradd -m -U -u 1000 pillow && \
     virtualenv2 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install nose cffi numpy olefile numpy pytest pytest-cov && \
     chown -R pillow:pillow /vpy && \
     virtualenv --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install nose cffi olefile pytest==4.1.1 pytest-cov && \
+    /vpy3/bin/pip install nose cffi numpy olefile pytest==4.1.1 pytest-cov && \
     chown -R pillow:pillow /vpy3
 
 USER pillow

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -35,10 +35,12 @@ RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
 
 RUN /sbin/useradd -m -U -u 1000 pillow && \
     virtualenv2 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi numpy olefile numpy pytest pytest-cov && \
+    /vpy/bin/pip install nose cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy && \
     virtualenv --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install nose cffi numpy olefile pytest==4.1.1 pytest-cov && \
+    /vpy3/bin/pip install nose cffi olefile pytest==4.1.1 pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy3
 
 USER pillow

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -36,11 +36,11 @@ RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
 RUN /sbin/useradd -m -U -u 1000 pillow && \
     virtualenv2 --system-site-packages /vpy && \
     /vpy/bin/pip install nose cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy && \
     virtualenv --system-site-packages /vpy3 && \
     /vpy3/bin/pip install nose cffi olefile pytest==4.1.1 pytest-cov && \
-    /vpy3/bin/pip install numpy --only-binary=:all: && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3
 
 USER pillow

--- a/archive/fedora-24-amd64/Dockerfile
+++ b/archive/fedora-24-amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd pillow && \
     chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install nose cffi olefile numpy nose-cov coverage cov-core && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/archive/fedora-25-amd64/Dockerfile
+++ b/archive/fedora-25-amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd pillow && \
     chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install nose cffi olefile numpy nose-cov coverage cov-core && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/archive/fedora-26-amd64/Dockerfile
+++ b/archive/fedora-26-amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd pillow && \
     chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/archive/fedora-27-amd64/Dockerfile
+++ b/archive/fedora-27-amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd pillow && \
     chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/archive/ubuntu-precise-amd64/Dockerfile
+++ b/archive/ubuntu-precise-amd64/Dockerfile
@@ -16,7 +16,7 @@ RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install -U pip --index-url=https://pypi.org/simple/ && \
     /vpy/bin/pip install -U setuptools wheel && \
     /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/archive/ubuntu-precise-amd64/Dockerfile
+++ b/archive/ubuntu-precise-amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN useradd pillow && addgroup pillow sudo
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install -U pip --index-url=https://pypi.org/simple/ && \
     /vpy/bin/pip install -U setuptools wheel && \
-    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install nose cffi olefile numpy nose-cov coverage cov-core && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/archive/ubuntu-precise-amd64/Dockerfile
+++ b/archive/ubuntu-precise-amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN useradd pillow && addgroup pillow sudo
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install -U pip --index-url=https://pypi.org/simple/ && \
     /vpy/bin/pip install -U setuptools wheel && \
-    /vpy/bin/pip install nose cffi olefile numpy nose-cov coverage cov-core && \
+    /vpy/bin/pip install nose cffi olefile nose-cov coverage cov-core && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/centos-6-amd64/Dockerfile
+++ b/centos-6-amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "source /opt/rh/python27/enable && \
     /opt/rh/python27/root/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
     cat /opt/rh/python27/enable /vpy/bin/activate > /vpy/bin/activate2.7 && \
     mv /vpy/bin/activate2.7 /vpy/bin/activate && \
     chown -R pillow:pillow /vpy && \

--- a/centos-6-amd64/Dockerfile
+++ b/centos-6-amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN bash -c "source /opt/rh/python27/enable && \
     chown -R pillow:pillow /vpy && \
     source /opt/rh/rh-python36/enable && \
     /opt/rh/rh-python36/root/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install cffi olefile numpy pytest pytest-cov && \
     cat /opt/rh/rh-python36/enable /vpy3/bin/activate > /vpy3/bin/activate3.6 && \
     mv /vpy3/bin/activate3.6 /vpy3/bin/activate && \
     chown -R pillow:pillow /vpy3"

--- a/centos-6-amd64/Dockerfile
+++ b/centos-6-amd64/Dockerfile
@@ -12,13 +12,15 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "source /opt/rh/python27/enable && \
     /opt/rh/python27/root/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     cat /opt/rh/python27/enable /vpy/bin/activate > /vpy/bin/activate2.7 && \
     mv /vpy/bin/activate2.7 /vpy/bin/activate && \
     chown -R pillow:pillow /vpy && \
     source /opt/rh/rh-python36/enable && \
     /opt/rh/rh-python36/root/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi olefile numpy pytest pytest-cov && \
+    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: && \
     cat /opt/rh/rh-python36/enable /vpy3/bin/activate > /vpy3/bin/activate3.6 && \
     mv /vpy3/bin/activate3.6 /vpy3/bin/activate && \
     chown -R pillow:pillow /vpy3"

--- a/centos-6-amd64/Dockerfile
+++ b/centos-6-amd64/Dockerfile
@@ -13,14 +13,14 @@ RUN useradd --uid 1000 pillow
 RUN bash -c "source /opt/rh/python27/enable && \
     /opt/rh/python27/root/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     cat /opt/rh/python27/enable /vpy/bin/activate > /vpy/bin/activate2.7 && \
     mv /vpy/bin/activate2.7 /vpy/bin/activate && \
     chown -R pillow:pillow /vpy && \
     source /opt/rh/rh-python36/enable && \
     /opt/rh/rh-python36/root/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy3/bin/pip install numpy --only-binary=:all: && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     cat /opt/rh/rh-python36/enable /vpy3/bin/activate > /vpy3/bin/activate3.6 && \
     mv /vpy3/bin/activate3.6 /vpy3/bin/activate && \
     chown -R pillow:pillow /vpy3"

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -14,14 +14,14 @@ RUN useradd --uid 1000 pillow
 RUN bash -c "source /opt/rh/python27/enable && \
     /opt/rh/python27/root/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     cat /opt/rh/python27/enable /vpy/bin/activate > /vpy/bin/activate2.7 && \
     mv /vpy/bin/activate2.7 /vpy/bin/activate && \
     chown -R pillow:pillow /vpy && \
     source /opt/rh/rh-python36/enable && \
     /opt/rh/rh-python36/root/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy3/bin/pip install numpy --only-binary=:all: && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     cat /opt/rh/rh-python36/enable /vpy3/bin/activate > /vpy3/bin/activate3.6 && \
     mv /vpy3/bin/activate3.6 /vpy3/bin/activate && \
     chown -R pillow:pillow /vpy3"

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN bash -c "source /opt/rh/python27/enable && \
     chown -R pillow:pillow /vpy && \
     source /opt/rh/rh-python36/enable && \
     /opt/rh/rh-python36/root/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install cffi olefile numpy pytest pytest-cov && \
     cat /opt/rh/rh-python36/enable /vpy3/bin/activate > /vpy3/bin/activate3.6 && \
     mv /vpy3/bin/activate3.6 /vpy3/bin/activate && \
     chown -R pillow:pillow /vpy3"

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -13,7 +13,7 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "source /opt/rh/python27/enable && \
     /opt/rh/python27/root/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
     cat /opt/rh/python27/enable /vpy/bin/activate > /vpy/bin/activate2.7 && \
     mv /vpy/bin/activate2.7 /vpy/bin/activate && \
     chown -R pillow:pillow /vpy && \

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -13,13 +13,15 @@ RUN useradd --uid 1000 pillow
 
 RUN bash -c "source /opt/rh/python27/enable && \
     /opt/rh/python27/root/usr/bin/virtualenv -p python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     cat /opt/rh/python27/enable /vpy/bin/activate > /vpy/bin/activate2.7 && \
     mv /vpy/bin/activate2.7 /vpy/bin/activate && \
     chown -R pillow:pillow /vpy && \
     source /opt/rh/rh-python36/enable && \
     /opt/rh/rh-python36/root/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi olefile numpy pytest pytest-cov && \
+    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: && \
     cat /opt/rh/rh-python36/enable /vpy3/bin/activate > /vpy3/bin/activate3.6 && \
     mv /vpy3/bin/activate3.6 /vpy3/bin/activate && \
     chown -R pillow:pillow /vpy3"

--- a/debian-stretch-x86/Dockerfile
+++ b/debian-stretch-x86/Dockerfile
@@ -46,10 +46,12 @@ RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi numpy olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p /usr/bin/python3.5 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi numpy olefile pytest pytest-cov && \
+    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/debian-stretch-x86/Dockerfile
+++ b/debian-stretch-x86/Dockerfile
@@ -46,10 +46,10 @@ RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi numpy olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p /usr/bin/python3.5 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install cffi numpy olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/debian-stretch-x86/Dockerfile
+++ b/debian-stretch-x86/Dockerfile
@@ -47,11 +47,11 @@ RUN useradd pillow && addgroup pillow sudo && \
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p /usr/bin/python3.5 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy3/bin/pip install numpy --only-binary=:all: && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/fedora-28-amd64/Dockerfile
+++ b/fedora-28-amd64/Dockerfile
@@ -13,9 +13,11 @@ RUN useradd pillow && \
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p /usr/bin/python3.6 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/fedora-28-amd64/Dockerfile
+++ b/fedora-28-amd64/Dockerfile
@@ -13,11 +13,11 @@ RUN useradd pillow && \
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p /usr/bin/python3.6 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy3/bin/pip install numpy --only-binary=:all: && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/fedora-29-amd64/Dockerfile
+++ b/fedora-29-amd64/Dockerfile
@@ -13,9 +13,11 @@ RUN useradd pillow && \
 
 RUN /usr/bin/python2.7 /usr/lib/python2.7/site-packages/virtualenv.py --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy && \
     /usr/bin/python3.7 /usr/lib/python3.7/site-packages/virtualenv.py --system-site-packages /vpy3 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/fedora-29-amd64/Dockerfile
+++ b/fedora-29-amd64/Dockerfile
@@ -13,11 +13,11 @@ RUN useradd pillow && \
 
 RUN /usr/bin/python2.7 /usr/lib/python2.7/site-packages/virtualenv.py --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy && \
     /usr/bin/python3.7 /usr/lib/python3.7/site-packages/virtualenv.py --system-site-packages /vpy3 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy3/bin/pip install numpy --only-binary=:all: && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-trusty-x86/Dockerfile
+++ b/ubuntu-trusty-x86/Dockerfile
@@ -46,7 +46,8 @@ RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/ubuntu-trusty-x86/Dockerfile
+++ b/ubuntu-trusty-x86/Dockerfile
@@ -47,7 +47,7 @@ RUN useradd pillow && addgroup pillow sudo && \
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/ubuntu-trusty-x86/Dockerfile
+++ b/ubuntu-trusty-x86/Dockerfile
@@ -46,7 +46,7 @@ RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile numpy pytest pytest-cov && \
     chown -R pillow:pillow /vpy
 
 ADD depends /depends

--- a/ubuntu-xenial-amd64/Dockerfile
+++ b/ubuntu-xenial-amd64/Dockerfile
@@ -15,10 +15,12 @@ RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi numpy olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p /usr/bin/python3.5 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi numpy olefile pytest pytest-cov && \
+    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-xenial-amd64/Dockerfile
+++ b/ubuntu-xenial-amd64/Dockerfile
@@ -16,11 +16,11 @@ RUN useradd pillow && addgroup pillow sudo && \
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
     /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: && \
+    /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p /usr/bin/python3.5 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy3/bin/pip install numpy --only-binary=:all: && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-xenial-amd64/Dockerfile
+++ b/ubuntu-xenial-amd64/Dockerfile
@@ -15,10 +15,10 @@ RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python2.7 --system-site-packages /vpy && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy/bin/pip install cffi numpy olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy && \
     virtualenv -p /usr/bin/python3.5 --system-site-packages /vpy3 && \
-    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install cffi numpy olefile pytest pytest-cov && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends


### PR DESCRIPTION
Update of and closes #25.

Install numpy, but only when there's a binary distribution, to avoid slow compiles from source.

```bash
pip install numpy --only-binary=:all: || true
```

`:all:` means for numpy and all its dependencies.

`|| true` is to prevent the command failing the whole build when there's only source distributions. In that case, we want to carry on without numpy.
