### PR TITLE
alpine updated to Python 3.7

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -38,7 +38,7 @@ RUN /usr/sbin/adduser -D pillow && \
     /vpy/bin/pip install olefile pytest pytest-cov && \
     /vpy/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy && \
-    virtualenv -p python3.6 /vpy3 && \
+    virtualenv -p python3.7 /vpy3 && \
     /vpy3/bin/pip install --upgrade pip && \
     /vpy3/bin/pip install olefile pytest pytest-cov && \
     /vpy3/bin/pip install numpy --only-binary=:all: || true && \


### PR DESCRIPTION
The alpine job is now failing in cron - https://travis-ci.org/python-pillow/docker-images/builds/550706398

Looks like alpine has updated Python 3 to 3.7 - https://travis-ci.org/python-pillow/docker-images/jobs/550706399#L287