### PR TITLE
Merge pull request #74 from radarhere/vpy3

### DIFF
--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -14,11 +14,11 @@ run yum install -y shadow-utils util-linux xorg-x11-xauth \
 RUN useradd --uid 1000 pillow
 
 RUN bash -c "/usr/bin/pip3 install virtualenv && \
-    /usr/bin/python3 -mvirtualenv -p /usr/bin/python3 --system-site-packages /vpy && \
-    /vpy/bin/pip install --upgrade pip && \
-    /vpy/bin/pip install cffi olefile pytest pytest-cov && \
-    /vpy/bin/pip install numpy --only-binary=:all: || true && \
-    chown -R pillow:pillow /vpy"
+    /usr/bin/python3 -mvirtualenv -p /usr/bin/python3 --system-site-packages /vpy3 && \
+    /vpy3/bin/pip install --upgrade pip && \
+    /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
+    /vpy3/bin/pip install numpy --only-binary=:all: || true && \
+    chown -R pillow:pillow /vpy3"
 
 ADD depends /depends
 RUN cd /depends && ./install_imagequant.sh && ./install_openjpeg.sh && ./install_raqm.sh

--- a/amazon-2-amd64/test.sh
+++ b/amazon-2-amd64/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /vpy/bin/activate
+source /vpy3/bin/activate
 cd /Pillow
 export DISPLAY=:99.0
 export LD_LIBRARY_PATH=/usr/lib


### PR DESCRIPTION
amazon-2-amd64 is the only active job that uses /vpy instead of /vpy3. For consistency, this PR resolves that.