### PR TITLE
Updated example docker commands

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -42,4 +42,4 @@ RUN /usr/sbin/adduser -D pillow && \
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pillow-alpine
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/alpine

--- a/amazon-1-amd64/Dockerfile
+++ b/amazon-1-amd64/Dockerfile
@@ -22,3 +22,4 @@ RUN cd /depends && ./install_imagequant.sh && ./install_openjpeg.sh
 USER pillow
 CMD ["depends/test.sh"]
 
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/amazon-1-amd64

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -26,3 +26,4 @@ RUN cd /depends && ./install_imagequant.sh && ./install_openjpeg.sh && ./install
 USER pillow
 CMD ["depends/test.sh"]
 
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/amazon-2-amd64

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -40,3 +40,4 @@ RUN /sbin/useradd -m -U -u 1000 pillow && \
 USER pillow
 CMD ["depends/test.sh"]
 
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/arch

--- a/centos-6-amd64/Dockerfile
+++ b/centos-6-amd64/Dockerfile
@@ -24,3 +24,5 @@ ADD depends /depends
 
 USER pillow
 CMD ["depends/test.sh"]
+
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/centos-6-amd64

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -24,3 +24,5 @@ ADD depends /depends
 
 USER pillow
 CMD ["depends/test.sh"]
+
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/centos-7-amd64

--- a/centos-8-amd64/Dockerfile
+++ b/centos-8-amd64/Dockerfile
@@ -26,3 +26,4 @@ ADD depends /depends
 USER pillow
 CMD ["depends/test.sh"]
 
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/centos-8-amd64

--- a/debian-10-buster-x86/Dockerfile
+++ b/debian-10-buster-x86/Dockerfile
@@ -58,4 +58,4 @@ USER pillow
 ENTRYPOINT ["linux32"]
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/ubuntu-trusty-x86
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/debian-10-buster-x86

--- a/debian-9-stretch-x86/Dockerfile
+++ b/debian-9-stretch-x86/Dockerfile
@@ -58,4 +58,4 @@ USER pillow
 ENTRYPOINT ["linux32"]
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/ubuntu-trusty-x86
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/debian-9-stretch-x86

--- a/ubuntu-18.04-bionic-amd64/Dockerfile
+++ b/ubuntu-18.04-bionic-amd64/Dockerfile
@@ -25,4 +25,4 @@ RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/ubuntu-ubuntu-18.04-bionic-amd64-amd64
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/ubuntu-18.04-bionic-amd64

--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -25,4 +25,4 @@ RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/ubuntu-ubuntu-20.04-focal-amd64-amd64
+#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/ubuntu-20.04-focal-amd64


### PR DESCRIPTION
Corrects some of the example docker commands, adds others to the Dockerfiles that are missing them.

For the record, the image names should aim to match https://hub.docker.com/u/pythonpillow/, the output of this repository.