### PR TITLE
Sort multi-line arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       env: DOCKER="centos-7-amd64"
     - name: "centos-8-amd64 stable"
       env: DOCKER="centos-8-amd64"
+    - name: "debian-10-buster-x86 stable"
+      env: DOCKER="debian-10-buster-x86"
     - name: "fedora-31-amd64 stable"
       env: DOCKER="fedora-31-amd64"
     - name: "fedora-32-amd64 stable"
@@ -29,8 +31,7 @@ matrix:
       env: DOCKER="ubuntu-18.04-bionic-amd64"
     - name: "ubuntu-20.04-focal-amd64 stable"
       env: DOCKER="ubuntu-20.04-focal-amd64"
-    - name: "debian-10-buster-x86 stable"
-      env: DOCKER="debian-10-buster-x86"
+
     - name: "alpine latest"
       env: DOCKER="alpine" LATEST="true"
     - name: "amazon-1-amd64 latest"
@@ -45,6 +46,8 @@ matrix:
       env: DOCKER="centos-7-amd64" LATEST="true"
     - name: "centos-8-amd64 latest"
       env: DOCKER="centos-8-amd64" LATEST="true"
+    - name: "debian-10-buster-x86 latest"
+      env: DOCKER="debian-10-buster-x86" LATEST="true"
     - name: "fedora-31-amd64 latest"
       env: DOCKER="fedora-31-amd64" LATEST="true"
     - name: "fedora-32-amd64 latest"
@@ -53,8 +56,7 @@ matrix:
       env: DOCKER="ubuntu-18.04-bionic-amd64" LATEST="true"
     - name: "ubuntu-20.04-focal-amd64 latest"
       env: DOCKER="ubuntu-20.04-focal-amd64" LATEST="true"
-    - name: "debian-10-buster-x86 latest"
-      env: DOCKER="debian-10-buster-x86" LATEST="true"
+
 install:
 - sudo apt-get update && sudo apt-get install -qyy debootstrap
 - sudo chown -R 1000 $TRAVIS_BUILD_DIR

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,33 +7,38 @@
 
 FROM alpine
 
-RUN apk --no-cache add python3 \
-                       build-base \
-                       python3-dev \
-                       # wget dependency
-                       openssl \
-                       # dev dependencies
-                       git \
-                       bash \
-                       sudo \
-                       py3-pip \
-                       # Pillow dependencies
-                       jpeg-dev \
-                       zlib-dev \
-                       freetype-dev \
-                       lcms2-dev \
-                       openjpeg-dev \
-                       tiff-dev \
-                       tk-dev \
-                       tcl-dev \
-                       harfbuzz-dev \
-                       fribidi-dev
+RUN apk --no-cache add \
+    build-base \
+    python3 \
+    python3-dev \
+    # wget dependency
+    openssl \
+    # dev dependencies
+    bash \
+    git \
+    py3-pip \
+    sudo \
+    # Pillow dependencies
+    freetype-dev \
+    fribidi-dev \
+    harfbuzz-dev \
+    jpeg-dev \
+    lcms2-dev \
+    openjpeg-dev \
+    tcl-dev \
+    tiff-dev \
+    tk-dev \
+    zlib-dev
 
 ADD depends /depends
-RUN cd /depends && ./install_webp.sh && ./install_imagequant.sh && ./install_raqm.sh
+RUN cd /depends && \
+    ./install_webp.sh && \
+    ./install_imagequant.sh && \
+    ./install_raqm.sh
 
 RUN /usr/sbin/adduser -D pillow && \
-    pip3 install -I virtualenv && virtualenv /vpy3 && \
+    pip3 install -I virtualenv && \
+    virtualenv /vpy3 && \
     /vpy3/bin/pip install --upgrade pip && \
     /vpy3/bin/pip install --upgrade setuptools>=49.3.2 && \
     /vpy3/bin/pip install olefile pytest pytest-cov && \

--- a/amazon-1-amd64/Dockerfile
+++ b/amazon-1-amd64/Dockerfile
@@ -1,12 +1,27 @@
 FROM amazonlinux:1
 
-run yum install -y shadow-utils util-linux xorg-x11-xauth \
-    findutils which \
-    python36 python36-virtualenv python36-devel \
-    gcc xorg-x11-server-Xvfb ghostscript sudo wget cmake \
-    libtiff-devel libjpeg-devel zlib-devel freetype-devel \
-    lcms2-devel libwebp-devel  \
-    libffi-devel
+run yum install -y \
+    cmake \
+    findutils \
+    freetype-devel \
+    gcc \
+    ghostscript \
+    lcms2-devel \
+    libffi-devel \
+    libjpeg-devel \
+    libtiff-devel \
+    libwebp-devel \
+    python36 \
+    python36-devel \
+    python36-virtualenv \
+    shadow-utils \
+    sudo \
+    util-linux \
+    wget \
+    which \
+    xorg-x11-server-Xvfb \
+    xorg-x11-xauth \
+    zlib-devel
 
 RUN useradd --uid 1000 pillow
 
@@ -17,7 +32,9 @@ RUN bash -c "/usr/bin/virtualenv-3.6 -p python3.6 --system-site-packages /vpy3 &
     chown -R pillow:pillow /vpy3"
 
 ADD depends /depends
-RUN cd /depends && ./install_imagequant.sh && ./install_openjpeg.sh
+RUN cd /depends && \
+    ./install_imagequant.sh && \
+    ./install_openjpeg.sh
 
 USER pillow
 CMD ["depends/test.sh"]

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -2,14 +2,35 @@ FROM amazonlinux:2
 
 run amazon-linux-extras install python3
 
-run yum install -y shadow-utils util-linux xorg-x11-xauth \
-    findutils which \
-    python3-devel python3-test python3-tkinter python3-virtualenv \
-    gcc xorg-x11-server-Xvfb ghostscript sudo wget cmake make \
-    libtiff-devel libjpeg-devel zlib-devel freetype-devel \
-    lcms2-devel libwebp-devel harfbuzz-devel fribidi-devel \
+run yum install -y \
+    cmake \
+    findutils \
+    freetype-devel \
+    fribidi-devel \
+    gcc \
+    gcc-c++ \
+    ghostscript \
+    harfbuzz-devel \
+    lcms2-devel \
     libffi-devel \
-    pth-devel gcc-c++ tar
+    libjpeg-devel \
+    libtiff-devel \
+    libwebp-devel \
+    make \
+    pth-devel \
+    python3-devel \
+    python3-test \
+    python3-tkinter \
+    python3-virtualenv \
+    shadow-utils \
+    sudo \
+    tar \
+    util-linux \
+    wget \
+    which \
+    xorg-x11-server-Xvfb \
+    xorg-x11-xauth \
+    zlib-devel
 
 RUN useradd --uid 1000 pillow
 
@@ -22,7 +43,10 @@ RUN bash -c "/usr/bin/pip3 install virtualenv && \
     chown -R pillow:pillow /vpy3"
 
 ADD depends /depends
-RUN cd /depends && ./install_imagequant.sh && ./install_openjpeg.sh && ./install_raqm.sh
+RUN cd /depends && \
+    ./install_imagequant.sh && \
+    ./install_openjpeg.sh && \
+    ./install_raqm.sh
 
 USER pillow
 CMD ["depends/test.sh"]

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -6,29 +6,34 @@ FROM greyltc/archlinux
 RUN pacman -Syu --noconfirm \
             wget
 RUN pacman -Sy --noconfirm \
-            python \
-            python-virtualenv \
-            gcc make git sudo \
-            python-setuptools \
-            extra/libjpeg-turbo \
-            extra/openjpeg2 \
-            extra/libtiff \
-            extra/lcms2 \
-            extra/libwebp \
             extra/freetype2 \
-            extra/tk \
-            libffi \
-            mesa-libgl \
-            xorg-server-xvfb \
-            ghostscript \
-            python-pyqt5 \
-            pkg-config \
             extra/fribidi \
-            extra/harfbuzz
+            extra/harfbuzz \
+            extra/lcms2 \
+            extra/libjpeg-turbo \
+            extra/libtiff \
+            extra/libwebp \
+            extra/openjpeg2 \
+            extra/tk \
+            gcc \
+            ghostscript \
+            git \
+            libffi \
+            make \
+            mesa-libgl \
+            pkg-config \
+            python \
+            python-pyqt5 \
+            python-setuptools \
+            python-virtualenv \
+            sudo \
+            xorg-server-xvfb
 
 
 ADD depends /depends
-RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
+RUN cd /depends && \
+     ./install_imagequant.sh && \
+     ./install_raqm.sh
 
 RUN /sbin/useradd -m -U -u 1000 pillow && \
     virtualenv --system-site-packages /vpy3 && \

--- a/archive/debian-9-stretch-x86/Dockerfile
+++ b/archive/debian-9-stretch-x86/Dockerfile
@@ -31,16 +31,34 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 # Pillow customization
 #
 
-RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y \
-    install xvfb sudo \
-    git wget python3-numpy python3-scipy netpbm \
-    ghostscript libffi-dev libjpeg-turbo-progs \
-    python3-setuptools virtualenv \
-    python3-dev cmake \
-    libtiff5-dev libjpeg62-turbo-dev libopenjp2-7-dev zlib1g-dev \
-    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev \
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    cmake \
+    ghostscript \
+    git \
+    libffi-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libharfbuzz-dev \
+    libjpeg-turbo-progs \
+    libjpeg62-turbo-dev \
+    liblcms2-dev \
+    libopenjp2-7-dev \
+    libtiff5-dev \
+    libwebp-dev \
+    netpbm \
+    python3-dev \
+    python3-numpy \
+    python3-scipy \
+    python3-setuptools \
     python3-tk \
-    libharfbuzz-dev libfribidi-dev && apt-get clean
+    sudo \
+    tcl8.6-dev \
+    tk8.6-dev \
+    virtualenv \
+    wget \
+    xvfb \
+    zlib1g-dev \
+    && apt-get clean
 
 RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow

--- a/archive/ubuntu-16.04-xenial-amd64/Dockerfile
+++ b/archive/ubuntu-16.04-xenial-amd64/Dockerfile
@@ -1,18 +1,39 @@
 FROM ubuntu:xenial
 
-RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y \
-    install sudo xvfb \
-    git wget virtualenv python3-numpy python3-scipy netpbm \
-    python3-pyqt5 ghostscript libffi-dev libjpeg-turbo-progs \
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    cmake \
+    ghostscript \
+    git \
+    libffi-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libharfbuzz-dev \
+    libjpeg-turbo-progs \
+    libjpeg8-dev \
+    liblcms2-dev \
+    libopenjp2-7-dev \
+    libtiff5-dev \
+    libwebp-dev \
+    netpbm \
+    python3-dev \
+    python3-numpy \
+    python3-pyqt5 \
+    python3-scipy \
     python3-setuptools \
-    python3-dev cmake  \
-    libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
-    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev \
     python3-tk \
-    libharfbuzz-dev libfribidi-dev && apt-get clean
+    sudo \
+    tcl8.6-dev \
+    tk8.6-dev \
+    virtualenv \
+    wget \
+    xvfb \
+    zlib1g-dev \
+    && apt-get clean
 
-RUN useradd pillow && addgroup pillow sudo && \
-    mkdir /home/pillow && chown pillow:pillow /home/pillow
+RUN useradd pillow && \
+    addgroup pillow sudo && \
+    mkdir /home/pillow && \
+    chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python3.5 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install --upgrade pip && \
@@ -21,7 +42,9 @@ RUN virtualenv -p /usr/bin/python3.5 --system-site-packages /vpy3 && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends
-RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
+RUN cd /depends && \
+    ./install_imagequant.sh && \
+    ./install_raqm.sh
 
 USER pillow
 CMD ["depends/test.sh"]

--- a/centos-6-amd64/Dockerfile
+++ b/centos-6-amd64/Dockerfile
@@ -1,12 +1,27 @@
 FROM centos:6
 
-run yum install -y epel-release centos-release-scl
+run yum install -y \
+    centos-release-scl \
+    epel-release
 
-run yum install -y rh-python36 rh-python36-python-virtualenv \
-    gcc xorg-x11-server-Xvfb ghostscript sudo \
-    libtiff-devel libjpeg-devel zlib-devel freetype-devel \
-    lcms2-devel libwebp-devel openjpeg2-devel tkinter \
-    tcl-devel tk-devel libffi-devel
+run yum install -y \
+    freetype-devel \
+    gcc \
+    ghostscript \
+    lcms2-devel \
+    libffi-devel \
+    libjpeg-devel \
+    libtiff-devel \
+    libwebp-devel \
+    openjpeg2-devel \
+    rh-python36 \
+    rh-python36-python-virtualenv \
+    sudo \
+    tcl-devel \
+    tk-devel \
+    tkinter \
+    xorg-x11-server-Xvfb \
+    zlib-devel
 
 RUN useradd --uid 1000 pillow
 

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -2,12 +2,28 @@ FROM centos:7
 
 run yum install -y epel-release centos-release-scl
 
-run yum install -y rh-python36 rh-python36-python-virtualenv \
-    gcc xorg-x11-server-Xvfb make which ghostscript sudo \
-    libtiff-devel libjpeg-devel zlib-devel freetype-devel \
-    lcms2-devel libwebp-devel openjpeg2-devel tkinter \
-    tcl-devel tk-devel libffi-devel libimagequant-devel \
-    libraqm-devel
+run yum install -y \
+    freetype-devel \
+    gcc \
+    ghostscript \
+    lcms2-devel \
+    libffi-devel \
+    libimagequant-devel \
+    libjpeg-devel \
+    libraqm-devel \
+    libtiff-devel \
+    libwebp-devel \
+    make \
+    openjpeg2-devel \
+    rh-python36 \
+    rh-python36-python-virtualenv \
+    sudo \
+    tcl-devel \
+    tk-devel \
+    tkinter \
+    which \
+    xorg-x11-server-Xvfb \
+    zlib-devel
 
 RUN useradd --uid 1000 pillow
 

--- a/centos-8-amd64/Dockerfile
+++ b/centos-8-amd64/Dockerfile
@@ -6,12 +6,28 @@ RUN yum install -y 'dnf-command(config-manager)'
 
 RUN yum config-manager --set-enabled PowerTools
 
-RUN yum install -y python3 python3-virtualenv \
-    gcc xorg-x11-server-Xvfb make which ghostscript sudo \
-    libtiff-devel libjpeg-devel zlib-devel freetype-devel \
-    lcms2-devel libwebp-devel openjpeg2-devel python3-tkinter \
-    tcl-devel tk-devel libffi-devel libimagequant-devel \
-    libraqm-devel
+RUN yum install -y \
+    freetype-devel \
+    gcc \
+    ghostscript \
+    lcms2-devel \
+    libffi-devel \
+    libimagequant-devel \
+    libjpeg-devel \
+    libraqm-devel \
+    libtiff-devel \
+    libwebp-devel \
+    make \
+    openjpeg2-devel \
+    python3 \
+    python3-tkinter \
+    python3-virtualenv \
+    sudo \
+    tcl-devel \
+    tk-devel \
+    which \
+    xorg-x11-server-Xvfb \
+    zlib-devel
 
 RUN useradd --uid 1000 pillow
 

--- a/debian-10-buster-x86/Dockerfile
+++ b/debian-10-buster-x86/Dockerfile
@@ -31,16 +31,35 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 # Pillow customization
 #
 
-RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y \
-    install xvfb sudo \
-    git wget python3-numpy python3-scipy netpbm \
-    python3-pyqt5 ghostscript libffi-dev libjpeg-turbo-progs \
-    python3-setuptools virtualenv \
-    python3-dev cmake \
-    libtiff5-dev libjpeg62-turbo-dev libopenjp2-7-dev zlib1g-dev \
-    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev \
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    cmake \
+    ghostscript \
+    git \
+    libffi-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libharfbuzz-dev \
+    libjpeg-turbo-progs \
+    libjpeg62-turbo-dev \
+    liblcms2-dev \
+    libopenjp2-7-dev \
+    libtiff5-dev \
+    libwebp-dev \
+    netpbm \
+    python3-dev \
+    python3-numpy \
+    python3-pyqt5 \
+    python3-scipy \
+    python3-setuptools \
     python3-tk \
-    libharfbuzz-dev libfribidi-dev && apt-get clean
+    sudo \
+    tcl8.6-dev \
+    tk8.6-dev \
+    virtualenv \
+    wget \
+    xvfb \
+    zlib1g-dev \
+    && apt-get clean
 
 RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow

--- a/fedora-31-amd64/Dockerfile
+++ b/fedora-31-amd64/Dockerfile
@@ -1,12 +1,26 @@
 FROM fedora:31
 
 RUN dnf install -y redhat-rpm-config \
-    python3-devel python3-virtualenv make gcc \
-    libtiff-devel libjpeg-devel zlib-devel freetype-devel \
-    lcms2-devel libwebp-devel openjpeg2-devel python3-tkinter \
-    tcl-devel tk-devel harfbuzz-devel fribidi-devel libraqm-devel \
+    freetype-devel \
+    fribidi-devel \
+    gcc \
+    harfbuzz-devel \
+    lcms2-devel \
     libimagequant-devel \
-    xorg-x11-server-Xvfb which
+    libjpeg-devel \
+    libraqm-devel \
+    libtiff-devel \
+    libwebp-devel \
+    make \
+    openjpeg2-devel \
+    python3-devel \
+    python3-tkinter \
+    python3-virtualenv \
+    tcl-devel \
+    tk-devel \
+    which \
+    xorg-x11-server-Xvfb \
+    zlib-devel
 
 RUN useradd pillow && \
     chown pillow:pillow /home/pillow

--- a/fedora-32-amd64/Dockerfile
+++ b/fedora-32-amd64/Dockerfile
@@ -1,12 +1,26 @@
 FROM fedora:32
 
 RUN dnf install -y redhat-rpm-config \
-    python3-devel python3-virtualenv make gcc \
-    libtiff-devel libjpeg-devel zlib-devel freetype-devel \
-    lcms2-devel libwebp-devel openjpeg2-devel python3-tkinter \
-    tcl-devel tk-devel harfbuzz-devel fribidi-devel libraqm-devel \
+    freetype-devel \
+    fribidi-devel \
+    gcc \
+    harfbuzz-devel \
+    lcms2-devel \
     libimagequant-devel \
-    xorg-x11-server-Xvfb which
+    libjpeg-devel \
+    libraqm-devel \
+    libtiff-devel \
+    libwebp-devel \
+    make \
+    openjpeg2-devel \
+    python3-devel \
+    python3-tkinter \
+    python3-virtualenv \
+    tcl-devel \
+    tk-devel \
+    which \
+    xorg-x11-server-Xvfb \
+    zlib-devel
 
 RUN useradd pillow && \
     chown pillow:pillow /home/pillow

--- a/ubuntu-18.04-bionic-amd64/Dockerfile
+++ b/ubuntu-18.04-bionic-amd64/Dockerfile
@@ -1,18 +1,38 @@
 FROM ubuntu:bionic
 
-RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y \
-    install sudo xvfb \
-    git wget virtualenv python3-numpy python3-scipy netpbm \
-    ghostscript libffi-dev libjpeg-turbo-progs \
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    cmake \
+    ghostscript \
+    git \
+    libffi-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libharfbuzz-dev \
+    libjpeg-turbo-progs \
+    libjpeg8-dev \
+    liblcms2-dev \
+    libopenjp2-7-dev \
+    libtiff5-dev \
+    libwebp-dev \
+    netpbm \
+    python3-dev \
+    python3-numpy \
+    python3-scipy \
     python3-setuptools \
-    python3-dev cmake  \
-    libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
-    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev \
     python3-tk \
-    libharfbuzz-dev libfribidi-dev && apt-get clean
+    sudo \
+    tcl8.6-dev \
+    tk8.6-dev \
+    virtualenv \
+    wget \
+    xvfb \
+    zlib1g-dev \
+    && apt-get clean
 
-RUN useradd pillow && addgroup pillow sudo && \
-    mkdir /home/pillow && chown pillow:pillow /home/pillow
+RUN useradd pillow && \
+    addgroup pillow sudo && \
+    mkdir /home/pillow && \
+    chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python3.6 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install --upgrade pip && \
@@ -20,7 +40,9 @@ RUN virtualenv -p /usr/bin/python3.6 --system-site-packages /vpy3 && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends
-RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
+RUN cd /depends && \
+    ./install_imagequant.sh && \
+    ./install_raqm.sh
 
 USER pillow
 CMD ["depends/test.sh"]

--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -1,18 +1,38 @@
 FROM ubuntu:focal
 
-RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y \
-    install sudo xvfb \
-    git wget virtualenv python3-numpy python3-scipy netpbm \
-    ghostscript libffi-dev libjpeg-turbo-progs \
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    cmake \
+    ghostscript \
+    git \
+    libffi-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libharfbuzz-dev \
+    libjpeg-turbo-progs \
+    libjpeg8-dev \
+    liblcms2-dev \
+    libopenjp2-7-dev \
+    libtiff5-dev \
+    libwebp-dev \
+    netpbm \
+    python3-dev \
+    python3-numpy \
+    python3-scipy \
     python3-setuptools \
-    python3-dev cmake  \
-    libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
-    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev \
     python3-tk \
-    libharfbuzz-dev libfribidi-dev && apt-get clean
+    sudo \
+    tcl8.6-dev \
+    tk8.6-dev \
+    virtualenv \
+    wget \
+    xvfb \
+    zlib1g-dev \
+    && apt-get clean
 
-RUN useradd pillow && addgroup pillow sudo && \
-    mkdir /home/pillow && chown pillow:pillow /home/pillow
+RUN useradd pillow && \
+    addgroup pillow sudo && \
+    mkdir /home/pillow && \
+    chown pillow:pillow /home/pillow
 
 RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install --upgrade pip && \
@@ -20,7 +40,9 @@ RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 && \
     chown -R pillow:pillow /vpy3
 
 ADD depends /depends
-RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
+RUN cd /depends && \
+    ./install_imagequant.sh && \
+    ./install_raqm.sh
 
 USER pillow
 CMD ["depends/test.sh"]


### PR DESCRIPTION
* Sort multi-line arguments

> Whenever possible, ease later changes by sorting multi-line arguments alphanumerically. This helps to avoid duplication of packages and make the list much easier to update. This also makes PRs a lot easier to read and review. Adding a space before a backslash (`\`) helps as well.

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#sort-multi-line-arguments

* Similarly, alphabetise CI jobs and add some spacing between groups
