### PR TITLE
Revert "Upgrade setuptools"

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -35,7 +35,6 @@ RUN cd /depends && ./install_webp.sh && ./install_imagequant.sh && ./install_raq
 RUN /usr/sbin/adduser -D pillow && \
     pip3 install -I virtualenv && virtualenv /vpy3 && \
     /vpy3/bin/pip install --upgrade pip && \
-    /vpy3/bin/pip install --upgrade setuptools>=49.3.2 && \
     /vpy3/bin/pip install olefile pytest pytest-cov && \
     /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -16,7 +16,6 @@ RUN useradd --uid 1000 pillow
 RUN bash -c "/usr/bin/pip3 install virtualenv && \
     /usr/bin/python3 -mvirtualenv -p /usr/bin/python3 --system-site-packages /vpy3 && \
     /vpy3/bin/pip install --upgrade pip && \
-    /vpy3/bin/pip install --upgrade setuptools>=49.3.2 && \
     /vpy3/bin/pip install cffi olefile pytest pytest-cov && \
     /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3"


### PR DESCRIPTION
Reverts part of #81. This is no longer needed to allow the builds to pass.