### PR TITLE
Add Mergify config

### DIFF
--- a/.github/.mergify.yml
+++ b/.github/.mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: Automatic merge
+    conditions:
+      - "#approved-reviews-by>=1"
+      - label=automerge
+      - status-success=continuous-integration/travis-ci/pr
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/4900.

This has these rules:

* approved by more than one person
* has `automerge` label
* Travis CI has passed

Note that you cannot approve your own PR. And the rules for GHA is a little different than Travis, so let's with the simpler repo.

Docs for reference: https://doc.mergify.io/actions.html#actions

# To test

When the CI is still running (or if it finished already, restart a job or the whole thing), approve and add the `automerge` label.

It should merge once the CI finishes.