### PR TITLE
arch: Upgrade setuptools

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -38,6 +38,7 @@ RUN cd /depends && \
 RUN /sbin/useradd -m -U -u 1000 pillow && \
     virtualenv --system-site-packages /vpy3 && \
     /vpy3/bin/pip install --upgrade pip && \
+    /vpy3/bin/pip install --upgrade setuptools>=49.3.2 && \
     /vpy3/bin/pip install nose cffi olefile pytest pytest-cov && \
     /vpy3/bin/pip install numpy --only-binary=:all: || true && \
     chown -R pillow:pillow /vpy3


### PR DESCRIPTION
Like https://github.com/python-pillow/docker-images/pull/81:

* Upgrade setuptools to >= 49.3.2 on arch. This is a temporary measure related to python-pillow/Pillow#4769
