### PR TITLE
Clear package manager cache for smaller images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,10 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Log image size
+        run: |
+          docker images
+
       - name: Push image
         if: "github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.target == 'stable'"
         run: make push-${{ matrix.image }} BRANCH=master

--- a/amazon-1-amd64/Dockerfile
+++ b/amazon-1-amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:1
 
-run yum install -y \
+RUN yum install -y \
     cmake \
     findutils \
     freetype-devel \
@@ -21,7 +21,8 @@ run yum install -y \
     which \
     xorg-x11-server-Xvfb \
     xorg-x11-xauth \
-    zlib-devel
+    zlib-devel \
+    && yum clean all
 
 RUN useradd --uid 1000 pillow
 

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -1,8 +1,8 @@
 FROM amazonlinux:2
 
-run amazon-linux-extras install python3
+RUN amazon-linux-extras install python3
 
-run yum install -y \
+RUN yum install -y \
     cmake \
     findutils \
     freetype-devel \
@@ -30,7 +30,8 @@ run yum install -y \
     which \
     xorg-x11-server-Xvfb \
     xorg-x11-xauth \
-    zlib-devel
+    zlib-devel \
+    && yum clean all
 
 RUN useradd --uid 1000 pillow
 

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -4,7 +4,9 @@
 FROM greyltc/archlinux
 
 RUN pacman -Syu --noconfirm \
-            wget
+            wget \
+    && find /var/cache/pacman/ -type f -delete
+
 RUN pacman -Sy --noconfirm \
             extra/freetype2 \
             extra/fribidi \
@@ -27,8 +29,8 @@ RUN pacman -Sy --noconfirm \
             python-setuptools \
             python-virtualenv \
             sudo \
-            xorg-server-xvfb
-
+            xorg-server-xvfb \
+    && find /var/cache/pacman/ -type f -delete
 
 ADD depends /depends
 RUN cd /depends && \

--- a/centos-6-amd64/Dockerfile
+++ b/centos-6-amd64/Dockerfile
@@ -1,10 +1,11 @@
 FROM centos:6
 
-run yum install -y \
+RUN yum install -y \
     centos-release-scl \
-    epel-release
+    epel-release \
+    && yum clean all
 
-run yum install -y \
+RUN yum install -y \
     freetype-devel \
     gcc \
     ghostscript \
@@ -21,7 +22,8 @@ run yum install -y \
     tk-devel \
     tkinter \
     xorg-x11-server-Xvfb \
-    zlib-devel
+    zlib-devel \
+    && yum clean all
 
 RUN useradd --uid 1000 pillow
 

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -1,8 +1,9 @@
 FROM centos:7
 
-run yum install -y epel-release centos-release-scl
+RUN yum install -y epel-release centos-release-scl \
+    && yum clean all
 
-run yum install -y \
+RUN yum install -y \
     freetype-devel \
     gcc \
     ghostscript \
@@ -23,7 +24,8 @@ run yum install -y \
     tkinter \
     which \
     xorg-x11-server-Xvfb \
-    zlib-devel
+    zlib-devel \
+    && yum clean all
 
 RUN useradd --uid 1000 pillow
 

--- a/centos-8-amd64/Dockerfile
+++ b/centos-8-amd64/Dockerfile
@@ -1,8 +1,10 @@
 FROM centos:8
 
-RUN yum install -y epel-release http://rpms.remirepo.net/enterprise/remi-release-8.rpm
+RUN yum install -y epel-release https://rpms.remirepo.net/enterprise/remi-release-8.rpm \
+    && yum clean all
 
-RUN yum install -y 'dnf-command(config-manager)'
+RUN yum install -y 'dnf-command(config-manager)' \
+    && yum clean all
 
 RUN yum config-manager --set-enabled PowerTools
 
@@ -27,7 +29,8 @@ RUN yum install -y \
     tk-devel \
     which \
     xorg-x11-server-Xvfb \
-    zlib-devel
+    zlib-devel \
+    && yum clean all
 
 RUN useradd --uid 1000 pillow
 

--- a/debian-10-buster-x86/Dockerfile
+++ b/debian-10-buster-x86/Dockerfile
@@ -59,7 +59,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     wget \
     xvfb \
     zlib1g-dev \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 RUN useradd pillow && addgroup pillow sudo && \
     mkdir /home/pillow && chown pillow:pillow /home/pillow

--- a/fedora-32-amd64/Dockerfile
+++ b/fedora-32-amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:32
 
-RUN dnf install -y redhat-rpm-config \
+RUN dnf install -y \
     freetype-devel \
     fribidi-devel \
     gcc \
@@ -16,11 +16,13 @@ RUN dnf install -y redhat-rpm-config \
     python3-devel \
     python3-tkinter \
     python3-virtualenv \
+    redhat-rpm-config \
     tcl-devel \
     tk-devel \
     which \
     xorg-x11-server-Xvfb \
-    zlib-devel
+    zlib-devel \
+    && dnf clean all
 
 RUN useradd pillow && \
     chown pillow:pillow /home/pillow

--- a/ubuntu-18.04-bionic-amd64/Dockerfile
+++ b/ubuntu-18.04-bionic-amd64/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     wget \
     xvfb \
     zlib1g-dev \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 RUN useradd pillow && \
     addgroup pillow sudo && \

--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     wget \
     xvfb \
     zlib1g-dev \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 RUN useradd pillow && \
     addgroup pillow sudo && \


### PR DESCRIPTION
We can save 10% of image size by clearing package manager caches: 

* `dnf clean all`
* `yum clean all`
* `find /var/cache/pacman/ -type f -delete`
* `rm -rf /var/lib/apt/lists/*`

Re: http://docs.projectatomic.io/container-best-practices/#_clearing_packaging_caches_and_temporary_package_downloads

Image | Size before | Size after | Amount smaller | Percent smaller
-- | --: | --: | --: | --:
alpine | 576 MB |   |   |  
amazon-1-amd64 | 661 MB | 614 MB | 47 MB | 7%
amazon-2-amd64 | 1.35 GB | 1.15 GB | 205 MB | 15%
arch | 1.9 GB | 1.69 GB | 215 MB | 11%
centos-6-amd64 | 983 MB | 774 MB | 209 MB | 21%
centos-7-amd64 | 847 MB | 650 MB | 197 MB | 23%
centos-8-amd64 | 730 MB | 645 MB | 85 MB | 12%
debian-10-buster-x86 | 1.41 GB | 1.41 GB | 0 GB | 0%
fedora-32-amd64 | 856 MB | 626 MB | 230 MB | 27%
ubuntu-18.04-bionic-amd64 | 932 MB | 898 MB | 34 MB | 4%
ubuntu-20.04-focal-amd64 | 961 MB | 935 MB | 26 MB | 3%
  |   |   |   |  
Total | 11.05 GB |   | 1.22 GB | 11%

Alpine uses `apk --no-cache`.