### PR TITLE
Add PySide6 to ubuntu-20.04-focal-amd64

### DIFF
--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -17,7 +17,12 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
+    libxcb-icccm4 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-render-util0 \
     libxkbcommon-dev \
+    libxkbcommon-x11-0 \
     netpbm \
     python3-dev \
     python3-numpy \

--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -4,16 +4,20 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
     ghostscript \
     git \
+    libegl-dev \
     libffi-dev \
     libfreetype6-dev \
     libfribidi-dev \
+    libgl-dev \
     libharfbuzz-dev \
     libjpeg-turbo-progs \
     libjpeg8-dev \
     liblcms2-dev \
+    libopengl-dev \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
+    libxkbcommon-dev \
     netpbm \
     python3-dev \
     python3-numpy \
@@ -36,7 +40,7 @@ RUN useradd pillow \
 
 RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov \
+    && /vpy3/bin/pip install --no-cache-dir cffi olefile pyside6 pytest pytest-cov \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends


### PR DESCRIPTION
Tested locally:

```sh
docker build ubuntu-20.04-focal-amd64 -t pillow-ubuntu-20.04-focal-amd64
docker run -t -i --rm pillow-ubuntu-20.04-focal-amd64 bash
```
```sh
/vpy3/bin/pip install https://github.com/hugovk/Pillow/archive/add-pyside6.zip
/vpy3/bin/python
```
```pycon
Python 3.8.5 (default, Jul 28 2020, 12:59:40)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import PIL
>>> PIL.__version__
'8.1.0.dev0'
>>> from PIL.ImageQt import qRgba
>>> from PySide6.QtGui import qRgb
>>> assert qRgb(0, 0, 0) == qRgba(0, 0, 0, 255)
>>>
```

---

Dependencies added by starting with the `master` and adding the libs it complains about:

```pycon
>>> from PySide6.QtGui import qRgb
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/vpy3/lib/python3.8/site-packages/shiboken6/files.dir/shibokensupport/__feature__.py", line 140, in _import
    return original_import(name, *args, **kwargs)
ImportError: libOpenGL.so.0: cannot open shared object file: No such file or directory
```
