### PR TITLE
Replaced $TRAVIS_BUILD_DIR with $GITHUB_WORKSPACE

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -47,4 +47,4 @@ RUN /usr/sbin/adduser -D pillow \
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/alpine
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/alpine

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -51,4 +51,4 @@ RUN cd /depends \
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/amazon-2-amd64
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/amazon-2-amd64

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -47,4 +47,4 @@ RUN /sbin/useradd -m -U -u 1000 pillow \
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/arch
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/arch

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -43,4 +43,4 @@ ADD depends /depends
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/centos-7-amd64
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/centos-7-amd64

--- a/centos-8-amd64/Dockerfile
+++ b/centos-8-amd64/Dockerfile
@@ -45,4 +45,4 @@ ADD depends /depends
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/centos-8-amd64
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/centos-8-amd64

--- a/debian-10-buster-x86/Dockerfile
+++ b/debian-10-buster-x86/Dockerfile
@@ -79,4 +79,4 @@ USER pillow
 ENTRYPOINT ["linux32"]
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/debian-10-buster-x86
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/debian-10-buster-x86

--- a/fedora-32-amd64/Dockerfile
+++ b/fedora-32-amd64/Dockerfile
@@ -38,4 +38,4 @@ ADD depends /depends
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/fedora-32-amd64
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/fedora-32-amd64

--- a/fedora-33-amd64/Dockerfile
+++ b/fedora-33-amd64/Dockerfile
@@ -39,4 +39,4 @@ ADD depends /depends
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/fedora-33-amd64
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/fedora-33-amd64

--- a/ubuntu-18.04-bionic-amd64/Dockerfile
+++ b/ubuntu-18.04-bionic-amd64/Dockerfile
@@ -47,4 +47,4 @@ RUN cd /depends \
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/ubuntu-18.04-bionic-amd64
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/ubuntu-18.04-bionic-amd64

--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -54,4 +54,4 @@ RUN cd /depends \
 USER pillow
 CMD ["depends/test.sh"]
 
-#docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/ubuntu-20.04-focal-amd64
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/ubuntu-20.04-focal-amd64


### PR DESCRIPTION
As seen in https://github.com/python-pillow/Pillow/blob/c377d8ca88d2618e603bcb43a180dee9611ad6c1/.github/workflows/test-docker.yml#L59