### PR TITLE
Revert "TEMP fix for arch breaking the builds"

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -7,11 +7,6 @@ RUN pacman -Syu --noconfirm \
             wget \
     && find /var/cache/pacman/ -type f -delete
 
-# Temporary fix for Arch breaking
-RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \
-    curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc" && \
-    bsdtar -C / -xvf "$patched_glibc"
-
 RUN pacman -Sy --noconfirm \
             extra/freetype2 \
             extra/fribidi \


### PR DESCRIPTION
Reverts a commit from #109, as the build now passes without it