### PR TITLE
Do not install zlib-devel

### DIFF
--- a/manylinux1-wheel-build/Dockerfile
+++ b/manylinux1-wheel-build/Dockerfile
@@ -17,7 +17,6 @@ RUN cd $SRC/pillow-wheels \
 FROM quay.io/pypa/manylinux1_x86_64:latest
 COPY --from=0 /usr/local/lib /usr/local/lib
 COPY --from=0 /usr/local/include /usr/local/include
-RUN yum install -y zlib-devel
 COPY build.sh /build.sh
 
 CMD ["/bin/sh /build.sh"]


### PR DESCRIPTION
The manylinux1 job is currently failing in master - https://github.com/python-pillow/docker-images/runs/2959691731?check_suite_focus=true#step:5:6380
> Step 12/14 : RUN yum install -y zlib-devel
>  ---> Running in eda741259570
> The command '/bin/sh -c yum install -y zlib-devel' returned a non-zero code: 139

As https://github.com/google/oss-fuzz/pull/5950 fixed Pillow after https://github.com/python-pillow/pillow-wheels/pull/204, this PR fixes this failure by skipping installing zlib-devel.