### PR TITLE
Add CentOS Stream 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           - "arch"
           - "centos-7-amd64"
           - "centos-8-amd64"
+          - "centos-stream-8-amd64"
           - "debian-10-buster-x86"
           - "fedora-33-amd64"
           - "fedora-34-amd64"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ TARGETS = \
 	arch \
 	centos-7-amd64 \
 	centos-8-amd64 \
+	centos-stream-8-amd64 \
 	debian-10-buster-x86 \
 	fedora-33-amd64 \
 	fedora-34-amd64 \

--- a/centos-stream-8-amd64/Dockerfile
+++ b/centos-stream-8-amd64/Dockerfile
@@ -1,0 +1,47 @@
+FROM quay.io/centos/centos:stream8
+
+RUN yum install -y epel-release https://rpms.remirepo.net/enterprise/remi-release-8.rpm \
+    && yum clean all
+
+RUN yum install -y 'dnf-command(config-manager)' \
+    && yum clean all
+
+RUN yum config-manager --set-enabled powertools
+
+RUN yum install -y \
+    freetype-devel \
+    gcc \
+    ghostscript \
+    lcms2-devel \
+    libffi-devel \
+    libimagequant-devel \
+    libjpeg-devel \
+    libraqm-devel \
+    libtiff-devel \
+    libwebp-devel \
+    make \
+    openjpeg2-devel \
+    python3 \
+    python3-tkinter \
+    python3-virtualenv \
+    tcl-devel \
+    tk-devel \
+    which \
+    xorg-x11-server-Xvfb \
+    zlib-devel \
+    && yum clean all
+
+RUN useradd --uid 1000 pillow
+
+RUN bash -c "/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 \
+    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
+    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
+    && chown -R pillow:pillow /vpy3"
+
+COPY depends /depends
+
+USER pillow
+CMD ["depends/test.sh"]
+
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/centos-stream-8-amd64

--- a/centos-stream-8-amd64/Makefile
+++ b/centos-stream-8-amd64/Makefile
@@ -1,0 +1,1 @@
+../Makefile.sub

--- a/centos-stream-8-amd64/test.sh
+++ b/centos-stream-8-amd64/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+source /vpy3/bin/activate
+cd /Pillow
+export DISPLAY=:99.0
+make clean
+make install-coverage
+python3 -c "from PIL import Image"
+/usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests

--- a/centos-stream-8-amd64/update.sh
+++ b/centos-stream-8-amd64/update.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker pull quay.io/centos/centos:stream8
+


### PR DESCRIPTION
CentOS is changing their release model.

After CentOS 8 comes CentOS Stream 8, and later CentOS Stream 9.

* https://blog.centos.org/2020/12/future-is-centos-stream/
* https://timor.site/2021/07/official-centos-8-stream-docker-image-finally-available/

`centos-stream-8-amd64` is based on `centos-8-amd64`.
