### PR TITLE
Compile Python 3.9 instead of using package Python 3.6

### DIFF
--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum install -y epel-release centos-release-scl \
+RUN yum install -y epel-release \
     && yum clean all
 
 RUN yum install -y \
@@ -16,12 +16,13 @@ RUN yum install -y \
     libwebp-devel \
     make \
     openjpeg2-devel \
-    rh-python36 \
-    rh-python36-python-virtualenv \
+    openssl-devel \
+    sqlite-devel \
     sudo \
     tcl-devel \
     tk-devel \
     tkinter \
+    wget \
     which \
     xorg-x11-server-Xvfb \
     zlib-devel \
@@ -29,13 +30,17 @@ RUN yum install -y \
 
 RUN useradd --uid 1000 pillow
 
-RUN bash -c "source /opt/rh/rh-python36/enable \
-    && /opt/rh/rh-python36/root/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 \
+RUN wget https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz \
+    && tar xzf Python-3.9.7.tgz \
+    && cd Python-3.9.7 \
+    && ./configure \
+    && make altinstall
+
+RUN bash -c "python3.9 -m pip install virtualenv \
+    && python3.9 -m virtualenv --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
     && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
     && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
-    && cat /opt/rh/rh-python36/enable /vpy3/bin/activate > /vpy3/bin/activate3.6 \
-    && mv /vpy3/bin/activate3.6 /vpy3/bin/activate \
     && chown -R pillow:pillow /vpy3"
 
 ADD depends /depends

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -34,7 +34,9 @@ RUN wget https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz \
     && tar xzf Python-3.9.7.tgz \
     && cd Python-3.9.7 \
     && ./configure \
-    && make altinstall
+    && make altinstall \
+    && cd .. \
+    && rm -r Python-3.9.7 Python-3.9.7.tgz
 
 RUN bash -c "python3.9 -m pip install virtualenv \
     && python3.9 -m virtualenv --system-site-packages /vpy3 \

--- a/centos-8-amd64/Dockerfile
+++ b/centos-8-amd64/Dockerfile
@@ -38,7 +38,9 @@ RUN wget https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz \
     && tar xzf Python-3.9.7.tgz \
     && cd Python-3.9.7 \
     && ./configure \
-    && make altinstall
+    && make altinstall \
+    && cd .. \
+    && rm -r Python-3.9.7 Python-3.9.7.tgz
 
 RUN bash -c "python3.9 -m pip install virtualenv \
     && python3.9 -m virtualenv --system-site-packages /vpy3 \

--- a/centos-8-amd64/Dockerfile
+++ b/centos-8-amd64/Dockerfile
@@ -21,12 +21,12 @@ RUN yum install -y \
     libwebp-devel \
     make \
     openjpeg2-devel \
-    python3 \
-    python3-tkinter \
-    python3-virtualenv \
+    openssl-devel \
+    sqlite-devel \
     sudo \
     tcl-devel \
     tk-devel \
+    wget \
     which \
     xorg-x11-server-Xvfb \
     zlib-devel \
@@ -34,7 +34,14 @@ RUN yum install -y \
 
 RUN useradd --uid 1000 pillow
 
-RUN bash -c "/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 \
+RUN wget https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz \
+    && tar xzf Python-3.9.7.tgz \
+    && cd Python-3.9.7 \
+    && ./configure \
+    && make altinstall
+
+RUN bash -c "python3.9 -m pip install virtualenv \
+    && python3.9 -m virtualenv --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
     && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
     && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \

--- a/centos-stream-8-amd64/Dockerfile
+++ b/centos-stream-8-amd64/Dockerfile
@@ -21,11 +21,11 @@ RUN yum install -y \
     libwebp-devel \
     make \
     openjpeg2-devel \
-    python3 \
-    python3-tkinter \
-    python3-virtualenv \
+    openssl-devel \
+    sqlite-devel \
     tcl-devel \
     tk-devel \
+    wget \
     which \
     xorg-x11-server-Xvfb \
     zlib-devel \
@@ -33,7 +33,14 @@ RUN yum install -y \
 
 RUN useradd --uid 1000 pillow
 
-RUN bash -c "/usr/bin/virtualenv -p python3.6 --system-site-packages /vpy3 \
+RUN wget https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz \
+    && tar xzf Python-3.9.7.tgz \
+    && cd Python-3.9.7 \
+    && ./configure \
+    && make altinstall
+
+RUN bash -c "python3.9 -m pip install virtualenv \
+    && python3.9 -m virtualenv --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
     && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
     && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \

--- a/centos-stream-8-amd64/Dockerfile
+++ b/centos-stream-8-amd64/Dockerfile
@@ -37,7 +37,9 @@ RUN wget https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz \
     && tar xzf Python-3.9.7.tgz \
     && cd Python-3.9.7 \
     && ./configure \
-    && make altinstall
+    && make altinstall \
+    && cd .. \
+    && rm -r Python-3.9.7 Python-3.9.7.tgz
 
 RUN bash -c "python3.9 -m pip install virtualenv \
     && python3.9 -m virtualenv --system-site-packages /vpy3 \

--- a/ubuntu-18.04-bionic-amd64/Dockerfile
+++ b/ubuntu-18.04-bionic-amd64/Dockerfile
@@ -12,18 +12,14 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libjpeg8-dev \
     liblcms2-dev \
     libopenjp2-7-dev \
+    libssl-dev \
+    libsqlite3-dev \
     libtiff5-dev \
     libwebp-dev \
     netpbm \
-    python3-dev \
-    python3-numpy \
-    python3-scipy \
-    python3-setuptools \
-    python3-tk \
     sudo \
     tcl8.6-dev \
     tk8.6-dev \
-    virtualenv \
     wget \
     xvfb \
     zlib1g-dev \
@@ -34,9 +30,16 @@ RUN useradd pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
-RUN virtualenv -p /usr/bin/python3.6 --system-site-packages /vpy3 \
+RUN wget https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz \
+    && tar xzf Python-3.9.7.tgz \
+    && cd Python-3.9.7 \
+    && ./configure \
+    && make altinstall
+
+RUN python3.9 -m pip install virtualenv \
+    && python3.9 -m virtualenv --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --no-cache-dir cffi numpy olefile pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-18.04-bionic-amd64/Dockerfile
+++ b/ubuntu-18.04-bionic-amd64/Dockerfile
@@ -34,7 +34,9 @@ RUN wget https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz \
     && tar xzf Python-3.9.7.tgz \
     && cd Python-3.9.7 \
     && ./configure \
-    && make altinstall
+    && make altinstall \
+    && cd .. \
+    && rm -r Python-3.9.7 Python-3.9.7.tgz
 
 RUN python3.9 -m pip install virtualenv \
     && python3.9 -m virtualenv --system-site-packages /vpy3 \


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/5768 suggests removing Ubuntu 18.04 and all CentOS versions as part of removing Python 3.6.

This PR suggests compiling Python 3.9 from source on those platforms instead.