### PR TITLE
Fix failing main build

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -7,6 +7,8 @@ RUN pacman -Syu --noconfirm \
             wget \
     && find /var/cache/pacman/ -type f -delete
 
+RUN pacman -Sy --noconfirm --overwrite "*libedit*,*readline.h,*histedit.h" libedit
+
 RUN pacman -Sy --noconfirm \
             extra/freetype2 \
             extra/fribidi \

--- a/manylinux2014-wheel-build/Dockerfile
+++ b/manylinux2014-wheel-build/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/pypa/manylinux2014_x86_64:latest
 
 run mkdir /src && mkdir /Pillow
 ENV SRC=/src
-ENV PATH=/opt/rh/devtoolset-2/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH=/opt/rh/devtoolset-9/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN git clone --depth 1 https://github.com/python-pillow/pillow-wheels /src/pillow-wheels
 

--- a/manylinux2014-wheel-build/build_depends.sh
+++ b/manylinux2014-wheel-build/build_depends.sh
@@ -26,5 +26,5 @@ export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH"
 . multibuild/library_builders.sh
 . config.sh
 
-yum install -y gcc gcc-c++
+yum install -y devtoolset-9-gcc devtoolset-9-gcc-c++
 pre_build


### PR DESCRIPTION
If I checkout main as main2, just to rerun it, it fails - https://github.com/python-pillow/docker-images/actions/runs/1632178894

This PR fixes those failures in arch and manylinux2014.