### PR TITLE
Install latest libwebp on s390x

### DIFF
--- a/ubuntu-20.04-focal-s390x/Dockerfile
+++ b/ubuntu-20.04-focal-s390x/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     liblcms2-dev \
     libopenjp2-7-dev \
     libtiff5-dev \
-    libwebp-dev \
     netpbm \
     python3-dev \
     python3-numpy \
@@ -43,7 +42,8 @@ RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 \
 ADD depends /depends
 RUN cd /depends \
     && ./install_imagequant.sh \
-    && ./install_raqm.sh
+    && ./install_raqm.sh \
+    && ./install_webp.sh
 
 USER pillow
 CMD ["depends/test.sh"]


### PR DESCRIPTION
I've found that [WebP itself has a problem on big endian architecture](https://github.com/python-pillow/Pillow/issues/4213#issuecomment-999840465). That fix should be released shortly as libwebp 1.2.2.

At the moment though, [only libwebp 0.6.1 is installed on the s390x job](https://github.com/python-pillow/docker-images/runs/4686262212#step:5:2670). When the new version of libwebp is released, I would like to test it on the big endian s390x job. So this PR runs `depends/install_webp.sh` from the main repository, upgrading the libwebp version.