### PR TITLE
Added meson

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -18,6 +18,7 @@ RUN apk --no-cache add \
     git \
     py3-pip \
     sudo \
+    meson \
     # Pillow dependencies
     freetype-dev \
     fribidi-dev \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,9 +16,9 @@ RUN apk --no-cache add \
     # dev dependencies
     bash \
     git \
+    meson \
     py3-pip \
     sudo \
-    meson \
     # Pillow dependencies
     freetype-dev \
     fribidi-dev \

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -19,12 +19,14 @@ RUN yum install -y \
     make \
     pth-devel \
     python3-devel \
+    python3-pip \
     python3-test \
     python3-tkinter \
     python3-virtualenv \
     shadow-utils \
     sudo \
     tar \
+    unzip \
     util-linux \
     wget \
     which \
@@ -43,6 +45,10 @@ RUN bash -c "/usr/bin/pip3 install virtualenv \
     && chown -R pillow:pillow /vpy3"
 
 ADD depends /depends
+RUN wget https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip \
+    && unzip ninja-linux.zip \
+    && mv ninja /usr/bin
+RUN /usr/bin/python3 -m pip install meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_openjpeg.sh \

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -25,6 +25,7 @@ RUN pacman -Sy --noconfirm \
             libffi \
             make \
             mesa-libgl \
+            meson \
             pkg-config \
             python \
             python-pyqt5 \

--- a/debian-10-buster-x86/Dockerfile
+++ b/debian-10-buster-x86/Dockerfile
@@ -46,8 +46,10 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libtiff5-dev \
     libwebp-dev \
     netpbm \
+    ninja-build \
     python3-dev \
     python3-numpy \
+    python3-pip \
     python3-pyqt5 \
     python3-setuptools \
     python3-tk \
@@ -72,6 +74,7 @@ RUN virtualenv -p /usr/bin/python3.7 --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
+RUN /usr/bin/python3.7 -m pip install meson
 RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
 
 USER pillow

--- a/debian-11-bullseye-x86/Dockerfile
+++ b/debian-11-bullseye-x86/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
+    meson \
     netpbm \
     python3-dev \
     python3-numpy \

--- a/ubuntu-18.04-bionic-amd64/Dockerfile
+++ b/ubuntu-18.04-bionic-amd64/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libtiff5-dev \
     libwebp-dev \
     netpbm \
+    ninja-build \
     sudo \
     tcl8.6-dev \
     tk8.6-dev \
@@ -45,6 +46,7 @@ RUN python3.9 -m pip install virtualenv \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
+RUN python3.9 -m pip install meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh

--- a/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
+++ b/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
     ghostscript \
     git \
+    meson \
     libffi-dev \
     libfreetype6-dev \
     libfribidi-dev \

--- a/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
+++ b/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
     ghostscript \
     git \
-    meson \
     libffi-dev \
     libfreetype6-dev \
     libfribidi-dev \
@@ -15,6 +14,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
+    meson \
     netpbm \
     python3.8-dbg \
     python3-dev \

--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libxcb-keysyms1 \
     libxcb-render-util0 \
     libxkbcommon-x11-0 \
+    meson \
     netpbm \
     python3-dev \
     python3-numpy \

--- a/ubuntu-20.04-focal-arm64v8/Dockerfile
+++ b/ubuntu-20.04-focal-arm64v8/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
     ghostscript \
     git \
+    meson \
     libffi-dev \
     libfreetype6-dev \
     libfribidi-dev \

--- a/ubuntu-20.04-focal-arm64v8/Dockerfile
+++ b/ubuntu-20.04-focal-arm64v8/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
     ghostscript \
     git \
-    meson \
     libffi-dev \
     libfreetype6-dev \
     libfribidi-dev \
@@ -16,6 +15,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
+    meson \
     netpbm \
     python3-dev \
     python3-numpy \

--- a/ubuntu-20.04-focal-ppc64le/Dockerfile
+++ b/ubuntu-20.04-focal-ppc64le/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
     ghostscript \
     git \
+    meson \
     libffi-dev \
     libfreetype6-dev \
     libfribidi-dev \

--- a/ubuntu-20.04-focal-ppc64le/Dockerfile
+++ b/ubuntu-20.04-focal-ppc64le/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
     ghostscript \
     git \
-    meson \
     libffi-dev \
     libfreetype6-dev \
     libfribidi-dev \
@@ -16,6 +15,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
+    meson \
     netpbm \
     python3-dev \
     python3-numpy \

--- a/ubuntu-20.04-focal-s390x/Dockerfile
+++ b/ubuntu-20.04-focal-s390x/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     liblcms2-dev \
     libopenjp2-7-dev \
     libtiff5-dev \
+    meson \
     netpbm \
     python3-dev \
     python3-numpy \


### PR DESCRIPTION
After https://github.com/python-pillow/Pillow/pull/5989 was merged, I reran GHA on main here, and found that [raqm wasn't installing](https://github.com/python-pillow/docker-images/runs/4958225915#step:5:803).

This is because [meson isn't present](https://github.com/python-pillow/docker-images/runs/4958225915#step:5:694), so this PR adds it to images that try to `install_raqm.sh`.

Some environments didn't have meson available as a package, or had a version of meson that was too old for raqm, so I installed meson through pip. amazon-2 had a version of ninja that was too old, so I downloaded a binary from their repository.