### PR TITLE
Link directly to workflow page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Images for the Pillow Test Infrastructure
 
-[![Docker images](https://github.com/python-pillow/docker-images/workflows/Docker%20images/badge.svg)](https://github.com/python-pillow/docker-images/actions?query=workflow%3A"Docker+Images")
+[![Docker images](https://github.com/python-pillow/docker-images/workflows/Docker%20images/badge.svg)](https://github.com/python-pillow/docker-images/actions/workflows/build.yml)
 
 ## Getting Started
 


### PR DESCRIPTION
https://github.com/python-pillow/docker-images/actions?query=workflow%3A%22Docker+Images%22 shows GHA workflows with a search query for the "Docker images" workflow.

https://github.com/python-pillow/docker-images/actions/workflows/build.yml links to the dedicated page for the "Docker images" workflow. This seems neater to me.