### PR TITLE
Do not install numpy twice

### DIFF
--- a/debian-10-buster-x86/Dockerfile
+++ b/debian-10-buster-x86/Dockerfile
@@ -70,7 +70,6 @@ RUN useradd pillow \
 RUN virtualenv -p /usr/bin/python3.7 --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
     && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
-    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/debian-11-bullseye-x86/Dockerfile
+++ b/debian-11-bullseye-x86/Dockerfile
@@ -69,7 +69,6 @@ RUN useradd pillow \
 RUN virtualenv -p /usr/bin/python3.9 --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
     && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
-    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends


### PR DESCRIPTION
numpy is  installed from a package in the Debian Dockerfiles

https://github.com/python-pillow/docker-images/blob/44db8908ab7a1bceacfdb0e1cc2b021e05a1ab57/debian-10-buster-x86/Dockerfile#L51
https://github.com/python-pillow/docker-images/blob/44db8908ab7a1bceacfdb0e1cc2b021e05a1ab57/debian-11-bullseye-x86/Dockerfile#L51

So do not install it again later through pip.