### PR TITLE
Fixed installing raqm 0.9.0

### DIFF
--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -10,6 +10,7 @@ RUN yum install -y \
     gcc \
     gcc-c++ \
     ghostscript \
+    git \
     harfbuzz-devel \
     lcms2-devel \
     libffi-devel \

--- a/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
+++ b/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
@@ -14,11 +14,12 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
-    meson \
     netpbm \
+    ninja-build \
     python3.8-dbg \
     python3-dev \
     python3-numpy \
+    python3-pip \
     python3-setuptools \
     python3-tk \
     sudo \
@@ -42,6 +43,7 @@ RUN virtualenv -p /usr/bin/python3.8-dbg --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
+RUN /usr/bin/python3.8-dbg -m pip install meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh

--- a/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
+++ b/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
@@ -43,7 +43,7 @@ RUN virtualenv -p /usr/bin/python3.8-dbg --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
-RUN /usr/bin/python3.8-dbg -m pip install meson
+RUN /usr/bin/python3.8-dbg -m pip install --no-cache-dir meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh

--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -21,10 +21,11 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libxcb-keysyms1 \
     libxcb-render-util0 \
     libxkbcommon-x11-0 \
-    meson \
     netpbm \
+    ninja-build \
     python3-dev \
     python3-numpy \
+    python3-pip \
     python3-setuptools \
     python3-tk \
     sudo \
@@ -47,6 +48,7 @@ RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
+RUN /usr/bin/python3 -m pip install meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh

--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -48,7 +48,7 @@ RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
-RUN /usr/bin/python3 -m pip install meson
+RUN /usr/bin/python3 -m pip install --no-cache-dir meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh

--- a/ubuntu-20.04-focal-ppc64le/Dockerfile
+++ b/ubuntu-20.04-focal-ppc64le/Dockerfile
@@ -15,10 +15,11 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
-    meson \
     netpbm \
+    ninja-build \
     python3-dev \
     python3-numpy \
+    python3-pip \
     python3-setuptools \
     python3-tk \
     sudo \
@@ -41,6 +42,7 @@ RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
+RUN python3.8 -m pip install meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh

--- a/ubuntu-20.04-focal-ppc64le/Dockerfile
+++ b/ubuntu-20.04-focal-ppc64le/Dockerfile
@@ -42,7 +42,7 @@ RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
-RUN python3.8 -m pip install meson
+RUN python3.8 -m pip install --no-cache-dir meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh

--- a/ubuntu-20.04-focal-s390x/Dockerfile
+++ b/ubuntu-20.04-focal-s390x/Dockerfile
@@ -14,10 +14,11 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     liblcms2-dev \
     libopenjp2-7-dev \
     libtiff5-dev \
-    meson \
     netpbm \
+    ninja-build \
     python3-dev \
     python3-numpy \
+    python3-pip \
     python3-setuptools \
     python3-tk \
     sudo \
@@ -40,6 +41,7 @@ RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
+RUN python3.8 -m pip install meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh \

--- a/ubuntu-20.04-focal-s390x/Dockerfile
+++ b/ubuntu-20.04-focal-s390x/Dockerfile
@@ -41,7 +41,7 @@ RUN virtualenv -p /usr/bin/python3.8 --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
-RUN python3.8 -m pip install meson
+RUN python3.8 -m pip install --no-cache-dir meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh \


### PR DESCRIPTION
After raqm was upgraded to 0.9.0 (https://github.com/python-pillow/Pillow/pull/6000), it stopped installing successfully on some images, reporting either `ERROR: Meson version is 0.53.2 but project requires >= 0.55.0`, or `meson.build:38:2: ERROR: Git program not found, cannot download freetype2.wrap via git.`

This resolves the problem, by either installing meson through pip rather than as a package, or adding the git package.