### PR TITLE
Further dependency improvements

### DIFF
--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -17,7 +17,6 @@ RUN yum install -y \
     libffi-devel \
     libjpeg-devel \
     libtiff-devel \
-    libwebp-devel \
     make \
     openssl-devel \
     pth-devel \
@@ -58,7 +57,8 @@ RUN /usr/bin/python3 -m pip install meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_openjpeg.sh \
-    && ./install_raqm.sh
+    && ./install_raqm.sh \
+    && ./install_webp.sh
 
 USER pillow
 CMD ["depends/test.sh"]

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -4,6 +4,7 @@ RUN amazon-linux-extras install python3
 
 RUN yum install -y \
     cmake \
+    curl \
     findutils \
     freetype-devel \
     fribidi-devel \
@@ -18,6 +19,7 @@ RUN yum install -y \
     libtiff-devel \
     libwebp-devel \
     make \
+    openssl-devel \
     pth-devel \
     python3-devel \
     python3-pip \
@@ -35,6 +37,9 @@ RUN yum install -y \
     xorg-x11-xauth \
     zlib-devel \
     && yum clean all
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd --uid 1000 pillow
 

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -10,6 +10,7 @@ RUN pacman -Syu --noconfirm \
 RUN pacman -Sy --noconfirm --overwrite "*libedit*,*readline.h,*histedit.h" libedit
 
 RUN pacman -Sy --noconfirm \
+            cargo \
             extra/freetype2 \
             extra/fribidi \
             extra/harfbuzz \

--- a/debian-10-buster-x86/Dockerfile
+++ b/debian-10-buster-x86/Dockerfile
@@ -33,6 +33,7 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
+    curl \
     ghostscript \
     git \
     libffi-dev \
@@ -45,6 +46,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
+    libssl-dev \
     netpbm \
     ninja-build \
     python3-dev \
@@ -61,6 +63,9 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     xvfb \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-host=i686-unknown-linux-gnu
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd pillow \
     && addgroup pillow sudo \

--- a/debian-11-bullseye-x86/Dockerfile
+++ b/debian-11-bullseye-x86/Dockerfile
@@ -33,6 +33,7 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
+    curl \
     ghostscript \
     git \
     libffi-dev \
@@ -45,6 +46,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libopenjp2-7-dev \
     libtiff5-dev \
     libwebp-dev \
+    libssl-dev \
     meson \
     netpbm \
     python3-dev \
@@ -60,6 +62,9 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     xvfb \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-host=i686-unknown-linux-gnu
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd pillow \
     && addgroup pillow sudo \

--- a/ubuntu-18.04-bionic-amd64/Dockerfile
+++ b/ubuntu-18.04-bionic-amd64/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
+    curl \
     ghostscript \
     git \
     libffi-dev \
@@ -25,6 +26,9 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     xvfb \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd pillow \
     && addgroup pillow sudo \

--- a/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
+++ b/ubuntu-20.04-focal-amd64-valgrind/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:focal
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
+    curl \
     ghostscript \
     git \
     libffi-dev \
@@ -12,6 +13,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libjpeg8-dev \
     liblcms2-dev \
     libopenjp2-7-dev \
+    libssl-dev \
     libtiff5-dev \
     libwebp-dev \
     netpbm \
@@ -31,6 +33,9 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     zlib1g-dev \
     valgrind \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd pillow \
     && addgroup pillow sudo \

--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:focal
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
+    curl \
     ghostscript \
     git \
     libegl-dev \
@@ -14,6 +15,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     liblcms2-dev \
     libopengl-dev \
     libopenjp2-7-dev \
+    libssl-dev \
     libtiff5-dev \
     libwebp-dev \
     libxcb-icccm4 \
@@ -36,6 +38,9 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     xvfb \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd pillow \
     && addgroup pillow sudo \

--- a/ubuntu-20.04-focal-arm64v8/Dockerfile
+++ b/ubuntu-20.04-focal-arm64v8/Dockerfile
@@ -2,6 +2,7 @@ FROM arm64v8/ubuntu:focal
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
+    curl \
     ghostscript \
     git \
     libffi-dev \
@@ -13,6 +14,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libjpeg8-dev \
     liblcms2-dev \
     libopenjp2-7-dev \
+    libssl-dev \
     libtiff5-dev \
     libwebp-dev \
     netpbm \
@@ -30,6 +32,9 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     xvfb \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd pillow \
     && addgroup pillow sudo \

--- a/ubuntu-20.04-focal-arm64v8/Dockerfile
+++ b/ubuntu-20.04-focal-arm64v8/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfreetype6-dev \
     libfribidi-dev \
     libharfbuzz-dev \
-    libimagequant-dev \
     libjpeg-turbo-progs \
     libjpeg8-dev \
     liblcms2-dev \

--- a/ubuntu-20.04-focal-ppc64le/Dockerfile
+++ b/ubuntu-20.04-focal-ppc64le/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfreetype6-dev \
     libfribidi-dev \
     libharfbuzz-dev \
-    libimagequant-dev \
     libjpeg-turbo-progs \
     libjpeg8-dev \
     liblcms2-dev \

--- a/ubuntu-20.04-focal-ppc64le/Dockerfile
+++ b/ubuntu-20.04-focal-ppc64le/Dockerfile
@@ -2,6 +2,7 @@ FROM ppc64le/ubuntu:focal
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
+    curl \
     ghostscript \
     git \
     libffi-dev \
@@ -13,6 +14,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libjpeg8-dev \
     liblcms2-dev \
     libopenjp2-7-dev \
+    libssl-dev \
     libtiff5-dev \
     libwebp-dev \
     netpbm \
@@ -30,6 +32,9 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     xvfb \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd pillow \
     && addgroup pillow sudo \


### PR DESCRIPTION
Since https://github.com/python-pillow/Pillow/pull/6014, libimagequant requires cargo. This PR
- installs it for various environments
- skips installing the libimagequant-dev package in two environments when install_imagequant.sh is already being run later
- while I'm here, upgrades webp on amazon-2-amd64 so that webpmux and WebP animation is supported