### PR TITLE
Removed auditwheel version restriction

### DIFF
--- a/manylinux2014-wheel-build/build.sh
+++ b/manylinux2014-wheel-build/build.sh
@@ -28,5 +28,5 @@ PATH=$PYBIN:$PATH make clean
 
 # Build and repair
 $PYBIN/pip --verbose wheel ${OPTS} -w /tmp /Pillow
-$PYBIN/pip install "auditwheel<5"
+$PYBIN/pip install auditwheel
 $PYBIN/python3 -m auditwheel repair /tmp/Pillow*whl -w /output


### PR DESCRIPTION
In #122, I restricted the version of auditwheel to be less than 5.
As recently as last month, [the job failed](https://github.com/radarhere/docker-images/runs/4850335606) without [that restriction.](https://github.com/radarhere/docker-images/commit/c77943e3110623a5573d0eea6de9d764938fd6d3)

Now it passes. My best guess is that something changed upstream.