### PR TITLE
Install libimagequant on Gentoo and CentOS

### DIFF
--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -4,12 +4,12 @@ RUN yum install -y epel-release \
     && yum clean all
 
 RUN yum install -y \
+    cargo \
     freetype-devel \
     gcc \
     ghostscript \
     lcms2-devel \
     libffi-devel \
-    libimagequant-devel \
     libjpeg-devel \
     libraqm-devel \
     libtiff-devel \
@@ -46,6 +46,9 @@ RUN bash -c "python3.9 -m pip install virtualenv \
     && chown -R pillow:pillow /vpy3"
 
 ADD depends /depends
+RUN cd /depends \
+    && ./install_imagequant.sh \
+    && ldconfig
 
 USER pillow
 CMD ["depends/test.sh"]

--- a/centos-stream-8-amd64/Dockerfile
+++ b/centos-stream-8-amd64/Dockerfile
@@ -9,12 +9,12 @@ RUN yum install -y 'dnf-command(config-manager)' \
 RUN yum config-manager --set-enabled powertools
 
 RUN yum install -y \
+    cargo \
     freetype-devel \
     gcc \
     ghostscript \
     lcms2-devel \
     libffi-devel \
-    libimagequant-devel \
     libjpeg-devel \
     libraqm-devel \
     libtiff-devel \
@@ -23,6 +23,7 @@ RUN yum install -y \
     openjpeg2-devel \
     openssl-devel \
     sqlite-devel \
+    sudo \
     tcl-devel \
     tk-devel \
     wget \
@@ -49,6 +50,9 @@ RUN bash -c "python3.9 -m pip install virtualenv \
     && chown -R pillow:pillow /vpy3"
 
 COPY depends /depends
+RUN cd /depends \
+    && ./install_imagequant.sh \
+    && ldconfig
 
 USER pillow
 CMD ["depends/test.sh"]

--- a/centos-stream-9-amd64/Dockerfile
+++ b/centos-stream-9-amd64/Dockerfile
@@ -6,6 +6,7 @@ RUN yum install -y 'dnf-command(config-manager)' \
 RUN yum config-manager --set-enabled crb
 
 RUN yum install -y \
+    cargo \
     cmake \
     freetype-devel \
     gcc \
@@ -42,7 +43,9 @@ RUN bash -c "python3.9 -m pip install virtualenv \
 
 COPY depends /depends
 RUN cd /depends \
-    && ./install_raqm.sh
+    && ./install_imagequant.sh \
+    && ./install_raqm.sh \
+    && ldconfig
 
 USER pillow
 CMD ["depends/test.sh"]

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -39,7 +39,7 @@ RUN virtualenv --system-site-packages /vpy3 \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends
-RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh
+RUN cd /depends && ./install_imagequant.sh && ./install_raqm.sh && ldconfig
 
 USER pillow
 CMD ["depends/test.sh"]


### PR DESCRIPTION
libimagequant has started failing in main - https://github.com/python-pillow/docker-images/runs/7651590158?check_suite_focus=true

I've found that running `ldconfig` fixes the problem.

Applying this further, libimagequant 4 can also be installed on CentOS.