### PR TITLE
Added openssl-devel to CentOS 9 to fix libimagequant install

### DIFF
--- a/centos-stream-9-amd64/Dockerfile
+++ b/centos-stream-9-amd64/Dockerfile
@@ -20,6 +20,7 @@ RUN yum install -y \
     make \
     meson \
     openjpeg2-devel \
+    openssl-devel \
     python3-devel \
     python3-pip \
     python3-tkinter \


### PR DESCRIPTION
I missed this in #152, as [libimagequant is not installed in CentOS 9 on main](https://github.com/python-pillow/docker-images/runs/7681791963?check_suite_focus=true#step:6:48). And you can see it [requesting that openssl-devel be installed.](https://github.com/python-pillow/docker-images/runs/7681791963?check_suite_focus=true#step:5:1916)

But with this change, [it works.](https://github.com/radarhere/docker-images/runs/7681825608?check_suite_focus=true#step:6:48)