### PR TITLE
Add dbg image for development/debugging purposes

### DIFF
--- a/ubuntu-22.04-jammy-amd64-valgrind/Dockerfile-dbg
+++ b/ubuntu-22.04-jammy-amd64-valgrind/Dockerfile-dbg
@@ -1,0 +1,26 @@
+FROM ubuntu-22.04-jammy-amd64-valgrind
+
+USER root
+RUN apt-get -qq update && apt-get install -y ubuntu-dbgsym-keyring
+
+RUN echo "deb http://ddebs.ubuntu.com jammy main restricted universe multiverse" > /etc/apt/sources.list.d/ddebs.list
+RUN echo "deb http://ddebs.ubuntu.com jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list.d/ddebs.list
+RUN perl -pi -e 's/# deb-src/deb-src/;' /etc/apt/sources.list
+
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    libfreetype6-dbgsym \
+    libtiff5-dbgsym \
+    libwebpmux3-dbgsym \
+    libwebp7-dbgsym \
+    libwebpdemux2-dbgsym \
+    libwebpmux3-dbgsym \
+    libopenjp2-7-dbgsym \
+    libharfbuzz0b-dbgsym \
+    libfribidi0-dbgsym \
+    emacs-nox
+
+RUN cd /usr/src && apt-get source freetype tiff libwebp libopenjp2-7 harfbuzz fribidi
+
+COPY setup.sh /depends/setup.sh
+USER pillow
+CMD ["/depends/setup.sh"]

--- a/ubuntu-22.04-jammy-amd64-valgrind/Makefile
+++ b/ubuntu-22.04-jammy-amd64-valgrind/Makefile
@@ -1,1 +1,40 @@
-../Makefile.sub
+WD = $(shell pwd)
+USERNAME := $(shell docker info | grep Username | xargs | cut -d ' ' -f 2)
+TARGET := $(notdir $(WD))
+ROOT := $(abspath $(WD)/../Pillow)
+IMAGENAME := $(if $(USERNAME), $(USERNAME)/$(TARGET), $(TARGET))
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+
+.PHONY: build
+build:
+	cp -r ../Pillow/depends .
+	cp test.sh depends
+	docker build -t $(IMAGENAME):$(BRANCH) .
+
+.PHONY: update
+update:
+	./update.sh
+
+.PHONY: test
+test:
+	docker run --rm -v $(ROOT):/Pillow $(IMAGENAME):$(BRANCH)
+
+.PHONY: push
+push:
+	docker push $(IMAGENAME):$(BRANCH)
+
+.PHONY: clean
+clean:
+	rm -r depends
+
+.PHONY: shell
+shell:
+	docker run --rm -it -v $(ROOT):/Pillow $(IMAGENAME):$(BRANCH) /bin/bash
+
+build-dbg:
+	docker build -t $(IMAGENAME)-dbg:$(BRANCH) -f Dockerfile-dbg .
+
+dbg:
+	docker run --privileged --rm -it -v $(ROOT):/Pillow $(IMAGENAME)-dbg:$(BRANCH)
+
+

--- a/ubuntu-22.04-jammy-amd64-valgrind/README-dbg.md
+++ b/ubuntu-22.04-jammy-amd64-valgrind/README-dbg.md
@@ -1,0 +1,52 @@
+# Debug image
+
+Sometimes we'll get an error that's most easily reproduced in the
+valgrind docker image. [citation needed]
+
+The `build-dbg` and `dbg` shell provide some symbols and debugging
+tools to fix that. Emacs is provided, as are some of the source packages.
+
+You may need to se source directories with the `set substitute-path`
+command.
+
+e.g.:
+
+```
+pillow@2f7a4ea5c959:/Pillow/oss-fuzz-tests$ gdb python
+GNU gdb (Ubuntu 12.1-0ubuntu1~22.04) 12.1
+Copyright (C) 2022 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+Type "show copying" and "show warranty" for details.
+This GDB was configured as "x86_64-linux-gnu".
+Type "show configuration" for configuration details.
+For bug reporting instructions, please see:
+<https://www.gnu.org/software/gdb/bugs/>.
+Find the GDB manual and other documentation resources online at:
+    <http://www.gnu.org/software/gdb/documentation/>.
+
+For help, type "help".
+Type "apropos word" to search for commands related to "word"...
+Reading symbols from python...
+(gdb) b _imagingft.c:922
+No source file named _imagingft.c.
+Make breakpoint pending on future shared library load? (y or [n]) y
+Breakpoint 1 (_imagingft.c:922) pending.
+(gdb) r f.py DejaVuSans-24-8-stripped.ttf
+Starting program: /vpy3/bin/python f.py DejaVuSans-24-8-stripped.ttf
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
+
+Breakpoint 1, font_render (self=0x7ffff70e9780, args=<optimized out>) at src/_imagingft.c:922
+922         if (!bitmap.buffer) {
+...
+0x00007ffff6fe4d6a in FT_Bitmap_Convert (library=<optimized out>, source=source@entry=0x7fffffffdff0, target=target@entry=0x7fffffffe020, alignment=alignment@entry=1) at ./src/base/ftbitmap.c:633
+633 ./src/base/ftbitmap.c: No such file or directory.
+(gdb) set substitute-path ./src /usr/src/freetype-2.11.1+dfsg/src/
+(gdb) f
+#0  0x00007ffff6fe4d6a in FT_Bitmap_Convert (library=<optimized out>, source=source@entry=0x7fffffffdff0, target=target@entry=0x7fffffffe020,
+    alignment=alignment@entry=1) at ./src/base/ftbitmap.c:633
+633             FT_Int  val = *ss;
+
+```

--- a/ubuntu-22.04-jammy-amd64-valgrind/README-dbg.md
+++ b/ubuntu-22.04-jammy-amd64-valgrind/README-dbg.md
@@ -6,7 +6,7 @@ valgrind docker image. [citation needed]
 The `build-dbg` and `dbg` shell provide some symbols and debugging
 tools to fix that. Emacs is provided, as are some of the source packages.
 
-You may need to se source directories with the `set substitute-path`
+You may need to set source directories with the `set substitute-path`
 command.
 
 e.g.:

--- a/ubuntu-22.04-jammy-amd64-valgrind/setup.sh
+++ b/ubuntu-22.04-jammy-amd64-valgrind/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+source /vpy3/bin/activate
+cd /Pillow
+make clean
+make install
+
+bash


### PR DESCRIPTION
Provides a new docker image `ubuntu-22.04-jammy-amd64-valgrind-dbg` with debug symbols, source, and  enough tools to track down extension issues that show up on the valgrind image. 