### PR TITLE
Add concurrency so old workflows are cancelled in favour of newer runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: Docker images
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.target }} + ${{ matrix.image }}


### PR DESCRIPTION
Like https://github.com/python-pillow/Pillow/pull/6621.

If there's more than one push to the same branch/PR, the older one will be cancelled so the newer one can run.

Travis CI had something like this.

This helps with backed up build queues, especially with slow-running CIs like this one.