### PR TITLE
Fix test docker image selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,8 @@ jobs:
         run: |
           cd "${{ matrix.test-image }}"
           make pull || (sudo chmod a+w . && make update && make build BRANCH=main)
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
       - name: Build image
         id: build
@@ -86,6 +88,8 @@ jobs:
         run: |
           cd "${{ matrix.image }}"
           make test BRANCH=main
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
       - name: Log image size
         run: |
@@ -97,6 +101,8 @@ jobs:
                            && github.ref == 'refs/heads/main'
                            && matrix.target == 'latest'"
         run: make push-${{ matrix.image }} BRANCH=main
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
       - name: Post build
         if: always()

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -1,8 +1,7 @@
 WD = $(shell pwd)
-USERNAME := $(shell docker info | grep Username | xargs | cut -d ' ' -f 2)
 TARGET := $(notdir $(WD))
 ROOT := $(abspath $(WD)/../Pillow)
-IMAGENAME := $(if $(USERNAME), $(USERNAME)/$(TARGET), $(TARGET))
+IMAGENAME := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TARGET), $(TARGET))
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
 .PHONY: build

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -3,6 +3,7 @@ TARGET := $(notdir $(WD))
 ROOT := $(abspath $(WD)/../Pillow)
 IMAGENAME := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TARGET), $(TARGET))
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+TEST_IMAGE := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TARGET):$(BRANCH), pythonpillow/$(TARGET):main)
 
 .PHONY: build
 build:
@@ -24,7 +25,7 @@ push:
 
 .PHONY: pull
 pull:
-	docker pull $(IMAGENAME):$(BRANCH)
+	docker pull $(TEST_IMAGE)
 
 .PHONY: clean
 clean:

--- a/manylinux2014-wheel-build/Makefile
+++ b/manylinux2014-wheel-build/Makefile
@@ -1,11 +1,10 @@
 WD = $(shell pwd)
-USERNAME := $(shell docker info | grep Username | xargs | cut -d ' ' -f 2)
 TARGET := $(notdir $(WD))
 ROOT := $(abspath $(WD)/../Pillow)
-IMAGENAME := $(if $(USERNAME), $(USERNAME)/$(TARGET), $(TARGET))
+IMAGENAME := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TARGET), $(TARGET))
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 TEST_TARGET = ubuntu-22.04-jammy-amd64
-TEST_IMAGE := $(if $(USERNAME), $(USERNAME)/$(TEST_TARGET), $(TEST_TARGET))
+TEST_IMAGE := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TEST_TARGET), $(TEST_TARGET))
 
 .PHONY: build
 build:

--- a/manylinux2014-wheel-build/Makefile
+++ b/manylinux2014-wheel-build/Makefile
@@ -4,7 +4,7 @@ ROOT := $(abspath $(WD)/../Pillow)
 IMAGENAME := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TARGET), $(TARGET))
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 TEST_TARGET = ubuntu-22.04-jammy-amd64
-TEST_IMAGE := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TEST_TARGET), $(TEST_TARGET))
+TEST_IMAGE := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TEST_TARGET):$(BRANCH), pythonpillow/$(TEST_TARGET):main)
 
 .PHONY: build
 build:
@@ -32,7 +32,7 @@ wheel:
 
 .PHONY: test
 test: 310
-	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(TEST_IMAGE):$(BRANCH) sh -c "/vpy3/bin/pip install /output/*cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl && cd /Pillow && /vpy3/bin/python selftest.py && /usr/bin/xvfb-run -a /vpy3/bin/pytest -vx"
+	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(TEST_IMAGE) sh -c "/vpy3/bin/pip install /output/*cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl && cd /Pillow && /vpy3/bin/python selftest.py && /usr/bin/xvfb-run -a /vpy3/bin/pytest -vx"
 
 .PHONY: push
 push:


### PR DESCRIPTION
Suggestions for merging into #161

When manylinux-2014-wheel-build runs, it attempts to pull from githubactions/ubuntu-22.04-jammy-amd64 - https://github.com/python-pillow/docker-images/actions/runs/3392741172/jobs/5650254050#step:5:7
> Error response from daemon: pull access denied for githubactions/ubuntu-22.04-jammy-amd64, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

In the case of this repository, incorrectly using "githubactions" because [docker isn't logged in for "Test Image Build", only afterwards in "Build image"](https://github.com/python-pillow/docker-images/blob/67d1b3e7ab66bcd078175bb98419e5ccab81751f/.github/workflows/build.yml#L67-L83). The simplest solution would to login to docker earlier.

However, when this is running in a forked repository, there is likely no `DOCKER_USERNAME` secret, and the images are not uploaded to Docker Hub. So the test image can't be downloaded from the fork. In that situation, it would seem better to use the pythonpillow test image. Deriving the username from "dockerinfo" doesn't seem simplest when we want to detect if docker is not logged in.

So this PR detects the `USERNAME` from the secret directly instead of using "docker info". If that is missing, then it pull the test image from pythonpillow.