### PR TITLE
Skip timeout checks on slower running valgrind job

### DIFF
--- a/ubuntu-22.04-jammy-amd64-valgrind/Makefile
+++ b/ubuntu-22.04-jammy-amd64-valgrind/Makefile
@@ -17,7 +17,7 @@ update:
 
 .PHONY: test
 test:
-	docker run --rm -v $(ROOT):/Pillow $(IMAGENAME):$(BRANCH)
+	docker run --rm -e "PILLOW_VALGRIND_TEST=true" -v $(ROOT):/Pillow $(IMAGENAME):$(BRANCH)
 
 .PHONY: push
 push:


### PR DESCRIPTION
Skip timeout checks on valgrind in this repository's jobs, like in the main repository with https://github.com/python-pillow/Pillow/pull/6842/commits/280330476345c10a3c95ef44b8dba260c6694502