### PR TITLE
Fix PySide6 in ubuntu-22.04-jammy-amd64

### DIFF
--- a/ubuntu-22.04-jammy-amd64/Dockerfile
+++ b/ubuntu-22.04-jammy-amd64/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libxcb-icccm4 \
     libxcb-image0 \
     libxcb-keysyms1 \
+    libxcb-randr0 \
     libxcb-render-util0 \
     libxkbcommon-x11-0 \
     meson \


### PR DESCRIPTION
ubuntu-22.04-jammy-amd64 has started failing at [Tests/test_qt_image_qapplication.py::test_sanity.](https://github.com/python-pillow/docker-images/actions/runs/4147773138/jobs/7178822440#step:7:3527)

Adding `export QT_DEBUG_PLUGINS=1`, I see that [the problem is](https://github.com/radarhere/docker-images/actions/runs/4210360378/jobs/7307989595#step:7:190)
> qt.core.library: "/vpy3/lib/python3.10/site-packages/PySide6/Qt/plugins/platforms/libqxcb.so" cannot load: Cannot load library /vpy3/lib/python3.10/site-packages/PySide6/Qt/plugins/platforms/libqxcb.so: (libxcb-randr.so.0: cannot open shared object file: No such file or directory)

So this PR adds libxcb-randr0.