### PR TITLE
Install x11-base/xorg-server 21.1.7 on gentoo

### DIFF
--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -24,7 +24,7 @@ RUN emerge --quiet -uDU @world
 RUN echo 'VIDEO_CARDS="fbdev dummy"' | cat >> /etc/portage/make.conf
 
 RUN USE="tk" emerge --quiet --getbinpkg=n dev-lang/python:3.9
-RUN emerge --quiet dev-python/virtualenv dev-util/cargo-c dev-util/meson sudo x11-misc/xvfb-run
+RUN emerge --quiet dev-python/virtualenv dev-util/cargo-c dev-util/meson sudo x11-misc/xvfb-run =x11-base/xorg-server-21.1.7
 
 # Install dependencies
 RUN USE="jpeg jpeg2k lcms tiff truetype webp xcb zlib" emerge --quiet --onlydeps dev-python/pillow


### PR DESCRIPTION
gentoo has started failing on main - https://github.com/python-pillow/docker-images/actions/runs/4211074983/jobs/7309181054#step:6:344

> !!! Multiple package instances within a single package slot have been pulled
> !!! into the dependency graph, resulting in a slot conflict:
>
> x11-base/xorg-server:0
>
>  (x11-base/xorg-server-21.1.7:0/21.1.7::gentoo, ebuild scheduled for merge) USE="elogind udev xorg xvfb -debug -minimal (-selinux) -suid -systemd -test -unwind -xcsecurity -xephyr -xnest" ABI_X86="(64)" pulled in by
>    x11-base/xorg-server[xvfb] required by (x11-misc/xvfb-run-1.20.10.3:0/0::gentoo, ebuild scheduled for merge) USE="" ABI_X86="(64)"
>                         ^^^^                                                                                                          
>
>  (x11-base/xorg-server-21.1.6-1:0/21.1.6::gentoo, binary scheduled for merge) USE="systemd udev xorg -debug -elogind -minimal (-selinux) -suid -test -unwind -xcsecurity -xephyr -xnest -xvfb" ABI_X86="(64)" pulled in by
>    x11-base/xorg-server:0/21.1.6= required by (x11-drivers/xf86-video-ati-19.1.0-r1-6:0/0::gentoo, binary scheduled for merge) USE="udev" ABI_X86="(64)"
>                        ^^^^^^^^^^                                                                                                                        
>    (and 6 more with the same problem)

Looking at that, I tried installing `=x11-base/xorg-server-21.1.7`, and that fixes it.