### PR TITLE
Replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           cd "${{ matrix.image }}" && sudo chmod a+w . && make update
           if [[ -n "$DOCKER_USERNAME" ]]; then
-            echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin && echo "{logged_in}={true}" >> $GITHUB_OUTPUT
+            echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin && echo "logged_in=true" >> $GITHUB_OUTPUT
           fi
           make build BRANCH=main
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           cd "${{ matrix.image }}" && sudo chmod a+w . && make update
           if [[ -n "$DOCKER_USERNAME" ]]; then
-            echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin && echo "::set-output name=logged_in::true"
+            echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin && echo "{logged_in}={true}" >> $GITHUB_OUTPUT
           fi
           make build BRANCH=main
         env:


### PR DESCRIPTION
There are warnings shown during builds, [for example](https://github.com/python-pillow/docker-images/actions/runs/4378634495):

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The link says:

> We are monitoring telemetry for the usage of these commands and plan to fully disable them on 31st May 2023. Starting 1st June 2023 workflows using `save-state` or `set-output` commands via stdout will fail with an error.

And to replace:

```yml
- name: Set output
  run: echo "::set-output name={name}::{value}"
```

With:

```yml
- name: Set output
  run: echo "{name}={value}" >> $GITHUB_OUTPUT
```