### PR TITLE
Drop support for soon-EOL Python 3.7

### DIFF
--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -1,7 +1,5 @@
 FROM amazonlinux:2
 
-RUN amazon-linux-extras install python3
-
 RUN yum install -y \
     cmake \
     curl \
@@ -19,15 +17,12 @@ RUN yum install -y \
     libtiff-devel \
     make \
     openssl-devel \
+    sqlite-devel \
     pth-devel \
-    python3-devel \
-    python3-pip \
-    python3-test \
-    python3-tkinter \
-    python3-virtualenv \
     shadow-utils \
     sudo \
     tar \
+    tk-devel \
     unzip \
     util-linux \
     wget \
@@ -42,8 +37,16 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd --uid 1000 pillow
 
-RUN bash -c "/usr/bin/pip3 install virtualenv \
-    && /usr/bin/python3 -mvirtualenv -p /usr/bin/python3 --system-site-packages /vpy3 \
+RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
+    && tar xzf Python-3.9.16.tgz \
+    && cd Python-3.9.16 \
+    && ./configure \
+    && make altinstall \
+    && cd .. \
+    && rm -r Python-3.9.16 Python-3.9.16.tgz
+
+RUN bash -c "python3.9 -m pip install virtualenv \
+    && python3.9 -m virtualenv --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
     && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
     && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
@@ -53,7 +56,8 @@ ADD depends /depends
 RUN wget https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip \
     && unzip ninja-linux.zip \
     && mv ninja /usr/bin
-RUN /usr/bin/python3 -m pip install meson
+RUN python3.9 -m pip install meson
+RUN ln -s /usr/local/bin/python3.9 /usr/bin/python3
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_openjpeg.sh \

--- a/centos-7-amd64/Dockerfile
+++ b/centos-7-amd64/Dockerfile
@@ -30,13 +30,13 @@ RUN yum install -y \
 
 RUN useradd --uid 1000 pillow
 
-RUN wget https://www.python.org/ftp/python/3.9.15/Python-3.9.15.tgz \
-    && tar xzf Python-3.9.15.tgz \
-    && cd Python-3.9.15 \
+RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
+    && tar xzf Python-3.9.16.tgz \
+    && cd Python-3.9.16 \
     && ./configure \
     && make altinstall \
     && cd .. \
-    && rm -r Python-3.9.15 Python-3.9.15.tgz
+    && rm -r Python-3.9.16 Python-3.9.16.tgz
 
 RUN bash -c "python3.9 -m pip install virtualenv \
     && python3.9 -m virtualenv --system-site-packages /vpy3 \

--- a/centos-stream-8-amd64/Dockerfile
+++ b/centos-stream-8-amd64/Dockerfile
@@ -34,13 +34,13 @@ RUN yum install -y \
 
 RUN useradd --uid 1000 pillow
 
-RUN wget https://www.python.org/ftp/python/3.9.15/Python-3.9.15.tgz \
-    && tar xzf Python-3.9.15.tgz \
-    && cd Python-3.9.15 \
+RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
+    && tar xzf Python-3.9.16.tgz \
+    && cd Python-3.9.16 \
     && ./configure \
     && make altinstall \
     && cd .. \
-    && rm -r Python-3.9.15 Python-3.9.15.tgz
+    && rm -r Python-3.9.16 Python-3.9.16.tgz
 
 RUN bash -c "python3.9 -m pip install virtualenv \
     && python3.9 -m virtualenv --system-site-packages /vpy3 \

--- a/manylinux2014-wheel-build/Makefile
+++ b/manylinux2014-wheel-build/Makefile
@@ -19,8 +19,6 @@ wheel:
 	-[ ! -d out ] && mkdir out
 	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(IMAGENAME):$(BRANCH) /build.sh $(_PYVER)
 
-37:
-	_PYVER=37 $(MAKE) wheel
 38:
 	_PYVER=38 $(MAKE) wheel
 39:

--- a/manylinux2014-wheel-build/README.md
+++ b/manylinux2014-wheel-build/README.md
@@ -18,7 +18,7 @@ The Makefile has several new commands:
 
 * make wheel: Makes a Python 3.10 manylinux2014 wheel, and puts it in the
 ./out directory.
-* make 37|38|39|310|311: These are specific commands to make
+* make 38|39|310|311: These are specific commands to make
 the corresponding 3.x version in the ./out directory.
 
 The test target here is mainly to validate the image build, it is

--- a/manylinux2014-wheel-build/build.sh
+++ b/manylinux2014-wheel-build/build.sh
@@ -16,7 +16,7 @@ fi
 # not strictly necessary, unless running multiple versions from the shell
 rm -f /tmp/*.whl || true
 
-# Python version, as 37,38,39,310,311. Defaults to 310.
+# Python version, as 38,39,310,311. Defaults to 310.
 # Matches the naming in /opt/python/
 PYVER=${1:-310}
 PYBIN=$(echo /opt/python/cp${PYVER}*/bin)

--- a/ubuntu-18.04-bionic-amd64/Dockerfile
+++ b/ubuntu-18.04-bionic-amd64/Dockerfile
@@ -35,13 +35,13 @@ RUN useradd pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
-RUN wget https://www.python.org/ftp/python/3.9.15/Python-3.9.15.tgz \
-    && tar xzf Python-3.9.15.tgz \
-    && cd Python-3.9.15 \
+RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
+    && tar xzf Python-3.9.16.tgz \
+    && cd Python-3.9.16 \
     && ./configure \
     && make altinstall \
     && cd .. \
-    && rm -r Python-3.9.15 Python-3.9.15.tgz
+    && rm -r Python-3.9.16 Python-3.9.16.tgz
 
 RUN python3.9 -m pip install virtualenv \
     && python3.9 -m virtualenv --system-site-packages /vpy3 \


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/7058

Python 3.7 will not be supported in the next version of Pillow. However, this is the packaged version of Python on Amazon Linux 2. So instead, this PR compiles Python 3.9 in that environment.

This PR also drops Python 3.7 from manylinux2014-wheel-build.