### PR TITLE
Do not install PyQt5

### DIFF
--- a/debian-11-bullseye-x86/Dockerfile
+++ b/debian-11-bullseye-x86/Dockerfile
@@ -51,7 +51,6 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     netpbm \
     python3-dev \
     python3-numpy \
-    python3-pyqt5 \
     python3-setuptools \
     python3-tk \
     sudo \


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/7059 has removed support for PyQt5, so don't install it in Debian.