### PR TITLE
Install libxcb-cursor0

### DIFF
--- a/ubuntu-20.04-focal-amd64/Dockerfile
+++ b/ubuntu-20.04-focal-amd64/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libssl-dev \
     libtiff5-dev \
     libwebp-dev \
+    libxcb-cursor0 \
     libxcb-icccm4 \
     libxcb-image0 \
     libxcb-keysyms1 \

--- a/ubuntu-22.04-jammy-amd64/Dockerfile
+++ b/ubuntu-22.04-jammy-amd64/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libssl-dev \
     libtiff5-dev \
     libwebp-dev \
+    libxcb-cursor0 \
     libxcb-icccm4 \
     libxcb-image0 \
     libxcb-keysyms1 \


### PR DESCRIPTION
Companion to https://github.com/python-pillow/Pillow/pull/7083

Fixes the two Ubuntu builds failing in main at the moment - https://github.com/python-pillow/docker-images/actions/runs/4720359699