### PR TITLE
Added manylinux_2_28 wheel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           - "ubuntu-22.04-jammy-amd64-valgrind"
           # has a dependency on the test image
           - "manylinux2014-wheel-build"
+          - "manylinux_2_28-wheel-build"
         include:
           - image: "manylinux2014-wheel-build"
             test-image: "ubuntu-22.04-jammy-amd64"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ TARGETS = \
 	fedora-38-amd64 \
 	gentoo \
 	manylinux2014-wheel-build \
+	manylinux_2_28-wheel-build \
 	ubuntu-20.04-focal-amd64 \
 	ubuntu-22.04-jammy-amd64 \
 	ubuntu-22.04-jammy-amd64-valgrind \

--- a/manylinux_2_28-wheel-build/Dockerfile
+++ b/manylinux_2_28-wheel-build/Dockerfile
@@ -1,0 +1,23 @@
+FROM quay.io/pypa/manylinux_2_28_x86_64:latest
+
+run mkdir /src && mkdir /Pillow
+ENV SRC=/src
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN git clone --depth 1 https://github.com/python-pillow/pillow-wheels /src/pillow-wheels
+
+COPY build_depends.sh /src
+copy yum_install /usr/local/bin
+
+RUN cd $SRC/pillow-wheels \
+    && git submodule update --init multibuild \
+    && bash $SRC/build_depends.sh
+
+
+FROM quay.io/pypa/manylinux_2_28_x86_64:latest
+COPY --from=0 /usr/local/lib /usr/local/lib
+COPY --from=0 /usr/local/include /usr/local/include
+RUN yum install -y zlib-devel
+COPY build.sh /build.sh
+
+CMD ["/bin/sh /build.sh"]

--- a/manylinux_2_28-wheel-build/Makefile
+++ b/manylinux_2_28-wheel-build/Makefile
@@ -1,0 +1,46 @@
+WD = $(shell pwd)
+TARGET := $(notdir $(WD))
+ROOT := $(abspath $(WD)/../Pillow)
+IMAGENAME := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TARGET), $(TARGET))
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+TEST_TARGET = ubuntu-22.04-jammy-amd64
+TEST_IMAGE := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TEST_TARGET):$(BRANCH), pythonpillow/$(TEST_TARGET):main)
+
+.PHONY: build
+build:
+	docker build -t $(IMAGENAME):$(BRANCH) .
+
+.PHONY: update
+update:
+	./update.sh
+
+.PHONY: wheel
+wheel:
+	-[ ! -d out ] && mkdir out
+	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(IMAGENAME):$(BRANCH) /build.sh $(_PYVER)
+
+38:
+	_PYVER=38 $(MAKE) wheel
+39:
+	_PYVER=39 $(MAKE) wheel
+310:
+	_PYVER=310 $(MAKE) wheel
+311:
+	_PYVER=311 $(MAKE) wheel
+
+.PHONY: test
+test: 310
+	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(TEST_IMAGE) sh -c "/vpy3/bin/pip install /output/*cp310-manylinux_2_28_x86_64.whl && cd /Pillow && /vpy3/bin/python selftest.py && /usr/bin/xvfb-run -a /vpy3/bin/pytest -vx"
+
+.PHONY: push
+push:
+	docker push $(IMAGENAME):$(BRANCH)
+
+.PHONY: clean
+clean:
+	-rm -r out
+
+.PHONY: shell
+shell:
+	docker run --rm -it -v $(ROOT):/Pillow $(IMAGENAME):$(BRANCH) /bin/bash
+

--- a/manylinux_2_28-wheel-build/README.md
+++ b/manylinux_2_28-wheel-build/README.md
@@ -1,0 +1,35 @@
+# Wheel Builder image
+
+This image is a little different than the other images in this repo --
+it's intended to be a quick way to build manylinux wheels with the
+production version of the libraries for debugging and testing
+purposes. This is designed to work as a single Docker image that
+doesn't require privilege or multiple images to run.
+
+Like the other images in this repo, it expects that there is a Pillow
+source directory mounted at /Pillow. Unlike the others, it puts the
+output files in /output. This should be mounted as a volume to the host
+to retrieve the finished wheel.
+
+Setting the environment variable `DEBUG=1` will create a build with
+symbols for debugging with Valgrind/GDB.
+
+The Makefile has several new commands:
+
+* make wheel: Makes a Python 3.10 manylinux_2_28 wheel, and puts it in the
+./out directory.
+* make 38|39|310|311: These are specific commands to make
+the corresponding 3.x version in the ./out directory.
+
+The test target here is mainly to validate the image build, it is
+assumed that the builds will be used for other purposes or tested in
+other images.
+
+
+# Sources
+
+* build_depends is from our integration with OSS-Fuzz
+* yum_install is syntactic sugar to make the multibuild repo work with
+  the base manylinux wheel image, rather than with its custom set of
+  images
+

--- a/manylinux_2_28-wheel-build/build.sh
+++ b/manylinux_2_28-wheel-build/build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -eu
+
+# options required to trigger the vendored Raqm install
+OPTS="--global-option build_ext --global-option --vendor-raqm --global-option --vendor-fribidi"
+
+CFLAGS=${CFLAGS:-}
+export CFLAGS="$CFLAGS --std=c99"
+
+# Check for debug build
+DEBUG=${DEBUG:-0}
+if [ $DEBUG ]; then
+    OPTS="--global-option build --global-option --debug $OPTS"
+    CFLAGS="$CFLAGS -Og -DDEBUG"
+fi
+
+# not strictly necessary, unless running multiple versions from the shell
+rm -f /tmp/*.whl || true
+
+# Python version, as 38,39,310,311. Defaults to 310.
+# Matches the naming in /opt/python/
+PYVER=${1:-310}
+PYBIN=$(echo /opt/python/cp${PYVER}*/bin)
+
+# We have to clean up the Pillow directories, otherwise we might get
+# cached builds that are not manylinux wheel compatible
+cd /Pillow
+PATH=$PYBIN:$PATH make clean
+
+# Build and repair
+$PYBIN/pip --verbose wheel ${OPTS} -w /tmp /Pillow
+$PYBIN/pip install auditwheel
+$PYBIN/python3 -m auditwheel repair /tmp/Pillow*whl -w /output

--- a/manylinux_2_28-wheel-build/build_depends.sh
+++ b/manylinux_2_28-wheel-build/build_depends.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+. multibuild/common_utils.sh
+
+export CONFIGURE_BUILD_SOURCED=1
+BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
+export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS"
+export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH"
+export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH"
+
+. multibuild/library_builders.sh
+. config.sh
+
+dnf group install -y "Development Tools"
+pre_build

--- a/manylinux_2_28-wheel-build/update.sh
+++ b/manylinux_2_28-wheel-build/update.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker pull quay.io/pypa/manylinux_2_28_x86_64:latest

--- a/manylinux_2_28-wheel-build/yum_install
+++ b/manylinux_2_28-wheel-build/yum_install
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+yum install -y $@


### PR DESCRIPTION
Adds a manylinux_2_28 wheel build, on top of our current manylinux2014 wheel build.

With that, we have [both of manylinux image types we use in pillow-wheels](https://github.com/python-pillow/pillow-wheels/blob/899d7c500525fdf1106f5e50c7027c997c3fd53e/.github/workflows/wheels-linux.yml#L34) and both of the non-EOL manylinux images from https://github.com/pypa/manylinux#docker-images.