### PR TITLE
Do not use install_imagequant.sh on Jammy

### DIFF
--- a/ubuntu-22.04-jammy-amd64-valgrind/Dockerfile
+++ b/ubuntu-22.04-jammy-amd64-valgrind/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:jammy
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    cargo \
     cmake \
     ghostscript \
     git \
@@ -9,6 +8,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfreetype6-dev \
     libfribidi-dev \
     libharfbuzz-dev \
+    libimagequant-dev \
     libjpeg-turbo-progs \
     libjpeg8-dev \
     liblcms2-dev \
@@ -45,7 +45,6 @@ RUN virtualenv -p /usr/bin/python3.10-dbg --system-site-packages /vpy3 \
 
 ADD depends /depends
 RUN cd /depends \
-    && ./install_imagequant.sh \
     && ./install_raqm.sh
 
 COPY python.supp /depends

--- a/ubuntu-22.04-jammy-amd64/Dockerfile
+++ b/ubuntu-22.04-jammy-amd64/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:jammy
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    cargo \
     cmake \
     ghostscript \
     git \
@@ -10,6 +9,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfreetype6-dev \
     libfribidi-dev \
     libharfbuzz-dev \
+    libimagequant-dev \
     libjpeg-turbo-progs \
     libjpeg8-dev \
     liblcms2-dev \
@@ -52,7 +52,6 @@ RUN virtualenv -p /usr/bin/python3.10 --system-site-packages /vpy3 \
 
 ADD depends /depends
 RUN cd /depends \
-    && ./install_imagequant.sh \
     && ./install_raqm.sh
 
 USER pillow

--- a/ubuntu-22.04-jammy-arm64v8/Dockerfile
+++ b/ubuntu-22.04-jammy-arm64v8/Dockerfile
@@ -1,7 +1,6 @@
 FROM arm64v8/ubuntu:jammy
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    cargo \
     cmake \
     ghostscript \
     git \
@@ -9,6 +8,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfreetype6-dev \
     libfribidi-dev \
     libharfbuzz-dev \
+    libimagequant-dev \
     libjpeg-turbo-progs \
     libjpeg8-dev \
     liblcms2-dev \
@@ -43,7 +43,6 @@ RUN virtualenv -p /usr/bin/python3.10 --system-site-packages /vpy3 \
 
 ADD depends /depends
 RUN cd /depends \
-    && ./install_imagequant.sh \
     && ./install_raqm.sh
 
 USER pillow

--- a/ubuntu-22.04-jammy-ppc64le/Dockerfile
+++ b/ubuntu-22.04-jammy-ppc64le/Dockerfile
@@ -1,7 +1,6 @@
 FROM ppc64le/ubuntu:jammy
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    cargo \
     cmake \
     ghostscript \
     git \
@@ -9,6 +8,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfreetype6-dev \
     libfribidi-dev \
     libharfbuzz-dev \
+    libimagequant-dev \
     libjpeg-turbo-progs \
     libjpeg8-dev \
     liblcms2-dev \
@@ -43,7 +43,6 @@ RUN virtualenv -p /usr/bin/python3.10 --system-site-packages /vpy3 \
 
 ADD depends /depends
 RUN cd /depends \
-    && ./install_imagequant.sh \
     && ./install_raqm.sh
 
 USER pillow

--- a/ubuntu-22.04-jammy-s390x/Dockerfile
+++ b/ubuntu-22.04-jammy-s390x/Dockerfile
@@ -41,7 +41,6 @@ RUN virtualenv -p /usr/bin/python3.10 --system-site-packages /vpy3 \
 
 ADD depends /depends
 RUN cd /depends \
-    && ./install_imagequant.sh \
     && ./install_raqm.sh \
     && ./install_webp.sh
 


### PR DESCRIPTION
Jammy [arm64v8](https://github.com/python-pillow/docker-images/actions/runs/5896905615/job/15995604376#step:6:2212) and [ppc64le](https://github.com/python-pillow/docker-images/actions/runs/5896905615/job/15995604497#step:6:2223) have started failing when installing libimagequant.

However, looking at the last passing run, they didn't actually successfully install libimagequant on [arm64v8](https://github.com/python-pillow/docker-images/actions/runs/5498282712/job/14886722900#step:7:621) and [ppc64le](https://github.com/python-pillow/docker-images/actions/runs/5498282712/job/14886722951#step:7:621). Neither did it install on [amd64](https://github.com/python-pillow/docker-images/actions/runs/5498282712/job/14886723026#step:7:620), and only the package version was detected on [s390x](https://github.com/python-pillow/docker-images/actions/runs/5498282712/job/14886722992#step:7:618).

So this PR fixes main by switching to just the package version of libimagequant on Jammy.