### PR TITLE
Updated Gentoo conf path and binhost name

### DIFF
--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -7,7 +7,7 @@ RUN echo 'FEATURES="${FEATURES} parallel-install parallel-fetch -merge-sync"' | 
 
 # TODO: May be able to drop this once changed to desktop docker images?
 # https://dilfridge.blogspot.com/2021/09/experimental-binary-gentoo-package.html
-RUN echo -e "[binhost]\npriority = 9999\nsync-uri = https://gentoo.osuosl.org/experimental/amd64/binpkg/default/linux/17.1/x86-64/\n" | cat >> /etc/portage/binrepos.conf
+RUN echo -e "[gentoobinhost]\npriority = 9999\nsync-uri = https://gentoo.osuosl.org/experimental/amd64/binpkg/default/linux/17.1/x86-64/\n" | cat >> /etc/portage/binrepos.conf/gentoobinhost.conf
 
 RUN echo 'EMERGE_DEFAULT_OPTS="--binpkg-respect-use=n --getbinpkg=y --autounmask-write --autounmask-continue --autounmask-keep-keywords=y --autounmask-use=y"' | cat >> /etc/portage/make.conf
 RUN echo 'USE="elogind -polkit"' | cat >> /etc/portage/make.conf


### PR DESCRIPTION
Gentoo has started failing in main - https://github.com/python-pillow/docker-images/actions/runs/6477775709/job/17588504307

A line to append config to a file
https://github.com/python-pillow/docker-images/blob/5695487c8850fd0403664d888f644377627660e3/gentoo/Dockerfile#L10
is causing https://github.com/python-pillow/docker-images/actions/runs/6477775709/job/17588504307#step:6:60
> 0.308 /bin/sh: line 1: /etc/portage/binrepos.conf: Is a directory

[Looking inside that directory](https://github.com/radarhere/docker-images/commit/b2f39de9e548c827940cdb867e914277f0371b01), [I see](https://github.com/radarhere/docker-images/actions/runs/6479339103/job/17592678965#step:6:46)
> gentoobinhost.conf

However, just[ updating our conf path to this new location](https://github.com/radarhere/docker-images/commit/361923a6305d341e771b948ec060fb51ea77becd) isn't sufficient - [it produces a variety of "Invalid binary package" messages](https://github.com/radarhere/docker-images/actions/runs/6479351127/job/17592716242#step:6:100).

[Getting the contents of the new conf file](https://github.com/radarhere/docker-images/commit/87935da437051045862a77833ed6ce69df9b0e15), [I see](https://github.com/radarhere/docker-images/actions/runs/6480601122/job/17596441541#step:6:46)
> \# These settings were set by the catalyst build script that automatically
> \# built this stage.
> \# Please consider using a local mirror.
> 
> [gentoobinhost]
> priority = 1
> sync-uri = https://gentoo.osuosl.org/releases/amd64/binpackages/17.1/x86-64

Our command uses 'binhost', this new conf file uses 'gentoobinhost'.

Updating both that name and the conf path resolves the problem.