### PR TITLE
Updated wheels script path

### DIFF
--- a/manylinux2014-wheel-build/build_depends.sh
+++ b/manylinux2014-wheel-build/build_depends.sh
@@ -23,8 +23,6 @@ export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS"
 export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH"
 export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH"
 
-. wheels/multibuild/library_builders.sh
-. wheels/config.sh
-
 yum install -y devtoolset-9-gcc devtoolset-9-gcc-c++
-pre_build
+
+. .github/workflows/wheels-dependencies.sh

--- a/manylinux_2_28-wheel-build/build_depends.sh
+++ b/manylinux_2_28-wheel-build/build_depends.sh
@@ -23,8 +23,6 @@ export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS"
 export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH"
 export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH"
 
-. wheels/multibuild/library_builders.sh
-. wheels/config.sh
-
 dnf group install -y "Development Tools"
-pre_build
+
+. .github/workflows/wheels-dependencies.sh


### PR DESCRIPTION
The [manylinux2014](https://github.com/python-pillow/docker-images/actions/runs/6988664889/job/19016463385) and [manylinux_2_28](https://github.com/python-pillow/docker-images/actions/runs/6988664889/job/19016463439) wheel build jobs are failing after https://github.com/python-pillow/Pillow/pull/7552.

This is because the script for building wheel dependencies has moved from `wheels/config.sh` to `.github/workflows/wheel-dependencies.sh`.

Also, that script now includes `wheels/multibuild/library_builders.sh` [by itself](https://github.com/python-pillow/Pillow/blob/e2ddd27500cdd4c8156bc0d5fe0bfa050408c707/.github/workflows/wheels-dependencies.sh#L10), and  runs the code immediately instead of needing `pre_build` to be called separately.

