### PR TITLE
Install Alpine virtualenv from package

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -19,6 +19,7 @@ RUN apk --no-cache add \
     git \
     meson \
     py3-pip \
+    py3-virtualenv \
     sudo \
     # Pillow dependencies
     freetype-dev \
@@ -40,7 +41,6 @@ RUN cd /depends \
     && ./install_raqm.sh
 
 RUN /usr/sbin/adduser -D pillow \
-    && pip3 install --no-cache-dir -I virtualenv \
     && virtualenv /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
     && /vpy3/bin/pip install --no-cache-dir olefile pytest pytest-cov pytest-timeout \


### PR DESCRIPTION
The alpine job has started failing, with [the message](https://github.com/python-pillow/docker-images/actions/runs/7149133414/job/19470989632#step:6:1487)
> The system-wide python installation should be maintained using the system package manager (apk) only.

This fixes it by installing virtualenv from the package, instead of through pip.