### PR TITLE
Removed unnecessary Gentoo Docker steps

### DIFF
--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -21,8 +21,6 @@ RUN emerge --quiet -uDU @world
 # We deliberately set this quite late on to avoid rebuilding e.g. mesa.
 RUN echo 'VIDEO_CARDS="fbdev dummy"' | cat >> /etc/portage/make.conf
 
-RUN echo 'dev-lang/python:3.9 tk' | cat >> /etc/portage/package.use/python
-RUN emerge --quiet dev-lang/python:3.9
 RUN emerge --quiet dev-python/virtualenv dev-util/cargo-c dev-build/meson x11-misc/xvfb-run
 
 # Install dependencies


### PR DESCRIPTION
Without this change, Gentoo tests on [Python 3.11 without Tkinter](https://github.com/python-pillow/docker-images/actions/runs/8211863196/job/22461362884#step:7:633).
With this change, [it does the same.](https://github.com/python-pillow/docker-images/actions/runs/8212805812/job/22463483866?pr=199#step:7:605)