### PR TITLE
Install setuptools on Fedora 40

### DIFF
--- a/fedora-40-amd64/Dockerfile
+++ b/fedora-40-amd64/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf install -y \
     make \
     openjpeg2-devel \
     python3-devel \
+    python3-setuptools \
     python3-tkinter \
     python3-virtualenv \
     redhat-rpm-config \


### PR DESCRIPTION
I've just found an error in the Fedora 40 build - https://github.com/python-pillow/docker-images/actions/runs/8866687018/job/24344407456#step:7:10
> Traceback (most recent call last):
>   File "/Pillow/setup.py", line 19, in <module>
>     from setuptools import Extension, setup
> ModuleNotFoundError: No module named 'setuptools'
> make: *** [Makefile:5: clean] Error 1