### PR TITLE
Replace `--no-cache-dir` with `PIP_NO_CACHE_DIR=1`

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -40,11 +40,14 @@ RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_raqm.sh
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN /usr/sbin/adduser -D --uid 1001 pillow \
     && virtualenv /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir olefile pytest pytest-cov pytest-timeout \
-    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3
 
 USER pillow

--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -45,11 +45,14 @@ RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
     && cd .. \
     && rm -r Python-3.9.16 Python-3.9.16.tgz
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN bash -c "python3.9 -m pip install virtualenv \
     && python3.9 -m virtualenv --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
-    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3"
 
 ADD depends /depends

--- a/amazon-2023-amd64/Dockerfile
+++ b/amazon-2023-amd64/Dockerfile
@@ -38,11 +38,14 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd --uid 1001 pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN bash -c "/usr/bin/pip3 install virtualenv \
     && /usr/bin/python3 -mvirtualenv -p /usr/bin/python3 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
-    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3"
 
 ADD depends /depends

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -41,11 +41,14 @@ RUN cd /depends \
      && ./install_imagequant.sh \
      && ./install_raqm.sh
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN /sbin/useradd -m -U --uid 1001 pillow \
     && virtualenv --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
-    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3
 
 USER pillow

--- a/centos-stream-9-amd64/Dockerfile
+++ b/centos-stream-9-amd64/Dockerfile
@@ -35,11 +35,14 @@ RUN yum install -y \
 
 RUN useradd --uid 1001 pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN bash -c "python3.9 -m pip install virtualenv \
     && python3.9 -m virtualenv --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
-    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3"
 
 COPY depends /depends

--- a/debian-12-bookworm-amd64/Dockerfile
+++ b/debian-12-bookworm-amd64/Dockerfile
@@ -69,9 +69,12 @@ RUN useradd --uid 1001 pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.11 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/debian-12-bookworm-x86/Dockerfile
+++ b/debian-12-bookworm-x86/Dockerfile
@@ -69,9 +69,12 @@ RUN useradd -u 1001 pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.11 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/fedora-39-amd64/Dockerfile
+++ b/fedora-39-amd64/Dockerfile
@@ -28,10 +28,13 @@ RUN dnf install -y \
 RUN useradd --uid 1001 pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.12 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
-    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/fedora-40-amd64/Dockerfile
+++ b/fedora-40-amd64/Dockerfile
@@ -28,10 +28,13 @@ RUN dnf install -y \
 RUN useradd --uid 1001 pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.12 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
-    && /vpy3/bin/pip install --no-cache-dir numpy --only-binary=:all: || true \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -30,9 +30,12 @@ RUN emerge --quiet app-text/ghostscript-gpl dev-python/numpy
 RUN useradd --uid 1001 pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-22.04-jammy-amd64-valgrind/Dockerfile
+++ b/ubuntu-22.04-jammy-amd64-valgrind/Dockerfile
@@ -38,9 +38,12 @@ RUN useradd --uid 1001 pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.10-dbg --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout pytest-valgrind \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout pytest-valgrind \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-22.04-jammy-amd64/Dockerfile
+++ b/ubuntu-22.04-jammy-amd64/Dockerfile
@@ -45,9 +45,12 @@ RUN useradd --uid 1001 pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.10 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pyside6 pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pyside6 pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-22.04-jammy-arm64v8/Dockerfile
+++ b/ubuntu-22.04-jammy-arm64v8/Dockerfile
@@ -36,9 +36,12 @@ RUN useradd --uid 1001 pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.10 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-24.04-noble-amd64/Dockerfile
+++ b/ubuntu-24.04-noble-amd64/Dockerfile
@@ -45,9 +45,12 @@ RUN useradd pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.12 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pyside6 pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pyside6 pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-24.04-noble-ppc64le/Dockerfile
+++ b/ubuntu-24.04-noble-ppc64le/Dockerfile
@@ -35,9 +35,12 @@ RUN useradd pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.12 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends

--- a/ubuntu-24.04-noble-s390x/Dockerfile
+++ b/ubuntu-24.04-noble-s390x/Dockerfile
@@ -33,9 +33,12 @@ RUN useradd pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
 RUN virtualenv -p /usr/bin/python3.12 --system-site-packages /vpy3 \
-    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
-    && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install --upgrade pip \
+    && /vpy3/bin/pip install cffi olefile pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends


### PR DESCRIPTION
Makes the `pip install` commands a bit shorter and easier to read.

Also add `PIP_DISABLE_PIP_VERSION_CHECK=1`, prevents warnings like this that sometimes shows up:

```
WARNING: You are using pip version 22.0.4; however, version 24.2 is available.
You should consider upgrading via the '/usr/local/bin/python3.9 -m pip install --upgrade pip' command.
```

Also use `ARG` instead of `ENV`:

* `ARG` - only available during the build
* `ENV` - also available inside the image

https://vsupalov.com/docker-arg-env-variable-guide/#arg-and-env
https://docs.docker.com/build/building/variables/