### PR TITLE
Fixed installing raqm on Gentoo

### DIFF
--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -21,7 +21,7 @@ RUN emerge --quiet -uDU @world
 # We deliberately set this quite late on to avoid rebuilding e.g. mesa.
 RUN echo 'VIDEO_CARDS="fbdev dummy"' | cat >> /etc/portage/make.conf
 
-RUN emerge --quiet dev-python/virtualenv dev-util/cargo-c dev-build/meson x11-misc/xvfb-run
+RUN emerge --quiet sudo dev-python/virtualenv dev-util/cargo-c dev-build/meson x11-misc/xvfb-run
 
 # Install dependencies
 RUN USE="jpeg jpeg2k lcms tiff truetype webp xcb zlib" emerge --quiet --onlydeps dev-python/pillow


### PR DESCRIPTION
Gentoo is missing raqm at the moment - https://github.com/python-pillow/docker-images/actions/runs/10968769999/job/30479325196#step:7:646

The error is at https://github.com/python-pillow/docker-images/actions/runs/10968769999/job/30479325196#step:6:1733
> ./install_raqm.sh: line 11: sudo: command not found

So this installs sudo to fix it.