### PR TITLE
Allow pip to be used when installing manylinux2014 dependencies

### DIFF
--- a/manylinux2014-wheel-build/build_depends.sh
+++ b/manylinux2014-wheel-build/build_depends.sh
@@ -25,4 +25,7 @@ export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH"
 
 yum install -y devtoolset-9-gcc devtoolset-9-gcc-c++
 
+PATH=/opt/_internal/tools/bin:$PATH
+python3 -m ensurepip
+
 . .github/workflows/wheels-dependencies.sh


### PR DESCRIPTION
Since https://github.com/python-pillow/Pillow/pull/8424 started using `pip install` when building wheel dependencies, the manylinux2014 job here has been failing - https://github.com/python-pillow/docker-images/actions/runs/11086849955/job/30804881761

This fixes it by adding a Python bin directory to the path and ensuring pip is present.