### PR TITLE
Do not install imagequant twice in Alpine

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -37,7 +37,6 @@ RUN apk --no-cache add \
 ADD depends /depends
 RUN cd /depends \
     && ./install_webp.sh \
-    && ./install_imagequant.sh \
     && ./install_raqm.sh
 
 ARG PIP_DISABLE_PIP_VERSION_CHECK=1


### PR DESCRIPTION
Alpine both installs the imagequant package
https://github.com/python-pillow/docker-images/blob/4f6ddabc6fd0577270c53814ee5608a9110a3184/alpine/Dockerfile#L30
and runs our install script.
https://github.com/python-pillow/docker-images/blob/4f6ddabc6fd0577270c53814ee5608a9110a3184/alpine/Dockerfile#L40

This switches to just the package.