### PR TITLE
Require x11-base/xorg-server 21.1.14 on Gentoo

### DIFF
--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -21,7 +21,7 @@ RUN emerge --quiet -uDU @world
 # We deliberately set this quite late on to avoid rebuilding e.g. mesa.
 RUN echo 'VIDEO_CARDS="fbdev dummy"' | cat >> /etc/portage/make.conf
 
-RUN emerge --quiet sudo dev-python/virtualenv dev-util/cargo-c dev-build/meson x11-misc/xvfb-run
+RUN emerge --quiet sudo dev-python/virtualenv dev-util/cargo-c dev-build/meson =x11-base/xorg-server-21.1.14 x11-misc/xvfb-run
 
 # Install dependencies
 RUN USE="jpeg jpeg2k lcms tiff truetype webp xcb zlib" emerge --quiet --onlydeps dev-python/pillow


### PR DESCRIPTION
gentoo is currently failing in main - https://github.com/python-pillow/docker-images/actions/runs/11641137059/job/32419281238

> #16 4.755 !!! Multiple package instances within a single package slot have been pulled
> #16 4.755 !!! into the dependency graph, resulting in a slot conflict:
> #16 4.755 
> #16 4.755 x11-base/xorg-server:0
> #16 4.755 
> #16 4.755   (x11-base/xorg-server-21.1.14:0/21.1.14::gentoo, ebuild scheduled for merge) USE="elogind udev xorg xvfb -debug -minimal (-selinux) -suid -systemd -test -unwind -xcsecurity -xephyr -xnest" ABI_X86="(64)" pulled in by
> #16 4.755     x11-base/xorg-server[xvfb] required by (x11-misc/xvfb-run-21.1.7.1:0/0::gentoo, ebuild scheduled for merge) USE="" ABI_X86="(64)"
> #16 4.755                          ^^^^                                                                                                         
> #16 4.755 
> #16 4.755   (x11-base/xorg-server-21.1.13-r1-2:0/21.1.13::gentoo, binary scheduled for merge) USE="elogind udev xorg -debug -minimal (-selinux) -suid -systemd -test -unwind -xcsecurity -xephyr -xnest -xvfb" ABI_X86="(64)" pulled in by
> #16 4.755     x11-base/xorg-server:0/21.1.13= required by (x11-drivers/xf86-video-dummy-0.4.1-6:0/0::gentoo, binary scheduled for merge) USE="" ABI_X86="(64)"
> #16 4.755                         ^^^^^^^^^^^                                                                                                                  
> #16 4.755     (and 2 more with the same problem)
> #16 4.755 
> #16 4.755 NOTE: Use the '--verbose-conflicts' option to display parents omitted above
> #16 4.755 
> #16 4.756 
> #16 4.756 The following USE changes are necessary to proceed:
> #16 4.756  (see "package.use" in the portage(5) man page for more details)
> #16 4.756 # required by x11-misc/xvfb-run-21.1.7.1::gentoo
> #16 4.756 # required by x11-misc/xvfb-run (argument)
> #16 4.756 >=x11-base/xorg-server-21.1.14 xvfb

Adding `=x11-base/xorg-server-21.1.14` fixes the failure.