### PR TITLE
Use platform flag under QEMU

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,13 @@ jobs:
             test-image: "ubuntu-24.04-noble-amd64"
           - image: "ubuntu-22.04-jammy-arm64v8"
             qemu-arch: "aarch64"
+            docker-args: "--platform linux/arm64"
           - image: "ubuntu-24.04-noble-ppc64le"
             qemu-arch: "ppc64le"
+            docker-args: "--platform linux/ppc64le"
           - image: "ubuntu-24.04-noble-s390x"
             qemu-arch: "s390x"
+            docker-args: "--platform linux/s390x"
 
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +81,7 @@ jobs:
           make pull || (sudo chmod a+w . && make update && make build BRANCH=main)
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_ARGS: ${{ matrix.docker-args }}
 
       - name: Build image
         id: build
@@ -90,6 +94,7 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_ARGS: ${{ matrix.docker-args }}
 
       - name: Test image
         run: |

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -9,7 +9,7 @@ TEST_IMAGE := $(if $(DOCKER_USERNAME), $(DOCKER_USERNAME)/$(TARGET):$(BRANCH), p
 build:
 	cp -r ../Pillow/depends .
 	cp test.sh depends
-	docker build -t $(IMAGENAME):$(BRANCH) .
+	docker build -t $(IMAGENAME):$(BRANCH) $(DOCKER_ARGS) .
 
 .PHONY: update
 update:
@@ -25,7 +25,7 @@ push:
 
 .PHONY: pull
 pull:
-	docker pull $(TEST_IMAGE)
+	docker pull $(DOCKER_ARGS) $(TEST_IMAGE)
 
 .PHONY: clean
 clean:

--- a/ubuntu-22.04-jammy-arm64v8/update.sh
+++ b/ubuntu-22.04-jammy-arm64v8/update.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker pull arm64v8/ubuntu:jammy
+docker pull $DOCKER_ARGS arm64v8/ubuntu:jammy

--- a/ubuntu-22.04-jammy-arm64v8/update.sh
+++ b/ubuntu-22.04-jammy-arm64v8/update.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker pull arm64v8/ubuntu:focal
+docker pull arm64v8/ubuntu:jammy

--- a/ubuntu-24.04-noble-ppc64le/update.sh
+++ b/ubuntu-24.04-noble-ppc64le/update.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker pull ppc64le/ubuntu:noble
+docker pull $DOCKER_ARGS ppc64le/ubuntu:noble

--- a/ubuntu-24.04-noble-s390x/update.sh
+++ b/ubuntu-24.04-noble-s390x/update.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker pull s390x/ubuntu:noble
+docker pull $DOCKER_ARGS s390x/ubuntu:noble


### PR DESCRIPTION
The jobs using different architectures have started failing in main - https://github.com/python-pillow/docker-images/actions/runs/11641137059/job/32419279827

> noble: Pulling from ppc64le/ubuntu
> no matching manifest for linux/amd64 in the manifest list entries

I asked about this recent change at https://github.com/docker-library/official-images/issues/17833. It was confirmed that yes, there was a recent change, and the solution is to start using `--platform`.