### PR TITLE
Install libjpeg-turbo8-dev

### DIFF
--- a/ubuntu-22.04-jammy-amd64-valgrind/Dockerfile
+++ b/ubuntu-22.04-jammy-amd64-valgrind/Dockerfile
@@ -8,8 +8,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfribidi-dev \
     libharfbuzz-dev \
     libimagequant-dev \
-    libjpeg-turbo-progs \
-    libjpeg8-dev \
+    libjpeg-turbo8-dev \
     liblcms2-dev \
     libopenjp2-7-dev \
     libssl-dev \

--- a/ubuntu-22.04-jammy-amd64/Dockerfile
+++ b/ubuntu-22.04-jammy-amd64/Dockerfile
@@ -9,8 +9,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfribidi-dev \
     libharfbuzz-dev \
     libimagequant-dev \
-    libjpeg-turbo-progs \
-    libjpeg8-dev \
+    libjpeg-turbo8-dev \
     liblcms2-dev \
     libopengl-dev \
     libopenjp2-7-dev \

--- a/ubuntu-22.04-jammy-arm64v8/Dockerfile
+++ b/ubuntu-22.04-jammy-arm64v8/Dockerfile
@@ -8,8 +8,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfribidi-dev \
     libharfbuzz-dev \
     libimagequant-dev \
-    libjpeg-turbo-progs \
-    libjpeg8-dev \
+    libjpeg-turbo8-dev \
     liblcms2-dev \
     libopenjp2-7-dev \
     libssl-dev \

--- a/ubuntu-24.04-noble-amd64/Dockerfile
+++ b/ubuntu-24.04-noble-amd64/Dockerfile
@@ -9,8 +9,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfribidi-dev \
     libharfbuzz-dev \
     libimagequant-dev \
-    libjpeg-turbo-progs \
-    libjpeg8-dev \
+    libjpeg-turbo8-dev \
     liblcms2-dev \
     libopengl-dev \
     libopenjp2-7-dev \

--- a/ubuntu-24.04-noble-ppc64le/Dockerfile
+++ b/ubuntu-24.04-noble-ppc64le/Dockerfile
@@ -8,8 +8,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfribidi-dev \
     libharfbuzz-dev \
     libimagequant-dev \
-    libjpeg-turbo-progs \
-    libjpeg8-dev \
+    libjpeg-turbo8-dev \
     liblcms2-dev \
     libopenjp2-7-dev \
     libssl-dev \

--- a/ubuntu-24.04-noble-s390x/Dockerfile
+++ b/ubuntu-24.04-noble-s390x/Dockerfile
@@ -8,8 +8,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libfribidi-dev \
     libharfbuzz-dev \
     libimagequant-dev \
-    libjpeg-turbo-progs \
-    libjpeg8-dev \
+    libjpeg-turbo8-dev \
     liblcms2-dev \
     libopenjp2-7-dev \
     libtiff5-dev \


### PR DESCRIPTION
On Ubuntu, install libjpeg-turbo8-dev rather than libjpeg-turbo-progs and libjpeg8-dev