### PR TITLE
Add PySide6 to Ubuntu 24.04 arm64v8

### DIFF
--- a/ubuntu-24.04-noble-arm64v8/Dockerfile
+++ b/ubuntu-24.04-noble-arm64v8/Dockerfile
@@ -4,16 +4,26 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     cmake \
     ghostscript \
     git \
+    libegl-dev \
     libfreetype6-dev \
     libfribidi-dev \
     libharfbuzz-dev \
     libimagequant-dev \
     libjpeg-turbo8-dev \
     liblcms2-dev \
+    libopengl-dev \
     libopenjp2-7-dev \
     libssl-dev \
     libtiff5-dev \
     libwebp-dev \
+    libxcb-cursor0 \
+    libxcb-icccm4 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-randr0 \
+    libxcb-render-util0 \
+    libxcb-shape0 \
+    libxkbcommon-x11-0 \
     meson \
     netpbm \
     python3-dev \
@@ -38,7 +48,7 @@ ARG PIP_NO_CACHE_DIR=1
 
 RUN virtualenv -p /usr/bin/python3.12 --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --upgrade pip \
-    && /vpy3/bin/pip install olefile pytest pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install olefile pyside6 pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3
 
 ADD depends /depends


### PR DESCRIPTION
I noticed differences between
https://github.com/python-pillow/docker-images/blob/main/ubuntu-24.04-noble-amd64/Dockerfile
and
https://github.com/python-pillow/docker-images/blob/main/ubuntu-24.04-noble-arm64v8/Dockerfile

This is essentially the same as #102, but for the arm64v8 Dockerfile.