### PR TITLE
Use action to setup qemu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,8 +60,9 @@ jobs:
 
       - name: Set up QEMU
         if: "matrix.qemu-arch"
-        run: |
-          docker run --rm --privileged aptman/qus -s -- -p ${{ matrix.qemu-arch }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.qemu-arch }}
 
       - name: Prepare build
         run: |


### PR DESCRIPTION
Similar to https://github.com/python-pillow/Pillow/pull/8819

The ppc64le and s390x jobs have been failing for a while. This fixes them by switching to https://github.com/docker/setup-qemu-action.