### PR TITLE
Update wheel names for auditwheel 6.4.0

### DIFF
--- a/manylinux2014-wheel-build/Makefile
+++ b/manylinux2014-wheel-build/Makefile
@@ -33,7 +33,7 @@ wheel:
 
 .PHONY: test
 test: 313
-	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(TEST_IMAGE) sh -c ". /vpy3/bin/activate && python3 -m pip install /output/*cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl && cd /Pillow && python3 selftest.py && /usr/bin/xvfb-run -a .ci/test.sh"
+	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(TEST_IMAGE) sh -c ". /vpy3/bin/activate && python3 -m pip install /output/*cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl && cd /Pillow && python3 selftest.py && /usr/bin/xvfb-run -a .ci/test.sh"
 
 .PHONY: push
 push:

--- a/manylinux_2_28-wheel-build/Makefile
+++ b/manylinux_2_28-wheel-build/Makefile
@@ -33,7 +33,7 @@ wheel:
 
 .PHONY: test
 test: 313
-	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(TEST_IMAGE) sh -c ". /vpy3/bin/activate && python3 -m pip install /output/*cp313-manylinux_2_28_x86_64.whl && cd /Pillow && python3 selftest.py && /usr/bin/xvfb-run -a .ci/test.sh"
+	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(TEST_IMAGE) sh -c ". /vpy3/bin/activate && python3 -m pip install /output/*cp313-*manylinux_2_28_x86_64.whl && cd /Pillow && python3 selftest.py && /usr/bin/xvfb-run -a .ci/test.sh"
 
 .PHONY: push
 push:


### PR DESCRIPTION
The wheel jobs have start failing, as the wheel filenames have changed.

https://github.com/python-pillow/docker-images/actions/runs/15375222298/job/43259197110 and 

> Fixed-up wheel written to /output/pillow-11.3.0.dev0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
> make[1]: Leaving directory '/home/runner/work/docker-images/docker-images/manylinux2014-wheel-build'
> docker run --rm -v /home/runner/work/docker-images/docker-images/Pillow:/Pillow -v `pwd`/out:/output  ***/fedora-41-amd64:main sh -c ". /vpy3/bin/activate && python3 -m pip install /output/*cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl && cd /Pillow && python3 selftest.py && /usr/bin/xvfb-run -a .ci/test.sh"
> WARNING: Requirement '/output/*cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl' looks like a filename, but the file does not exist

https://github.com/python-pillow/docker-images/actions/runs/15375222298/job/43259197111

> Fixed-up wheel written to /output/pillow-11.3.0.dev0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
> make[1]: Leaving directory '/home/runner/work/docker-images/docker-images/manylinux_2_28-wheel-build'
> docker run --rm -v /home/runner/work/docker-images/docker-images/Pillow:/Pillow -v `pwd`/out:/output  ***/fedora-41-amd64:main sh -c ". /vpy3/bin/activate && python3 -m pip install /output/*cp313-manylinux_2_28_x86_64.whl && cd /Pillow && python3 selftest.py && /usr/bin/xvfb-run -a .ci/test.sh"
> WARNING: Requirement '/output/*cp313-manylinux_2_28_x86_64.whl' looks like a filename, but the file does not exist

This would be due to auditwheel 6.4.0 and at least partly https://github.com/pypa/auditwheel/pull/584.

In this PR, I've updated the expected filenames.