### PR TITLE
Drop Python 3.9 from manylinux builds

### DIFF
--- a/manylinux2014-wheel-build/Makefile
+++ b/manylinux2014-wheel-build/Makefile
@@ -20,8 +20,6 @@ wheel:
 	-[ ! -d out ] && mkdir out
 	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(IMAGENAME):$(BRANCH) /build.sh $(_PYVER)
 
-39:
-	_PYVER=39 $(MAKE) wheel
 310:
 	_PYVER=310 $(MAKE) wheel
 311:

--- a/manylinux2014-wheel-build/README.md
+++ b/manylinux2014-wheel-build/README.md
@@ -18,7 +18,7 @@ The Makefile has several new commands:
 
 * make wheel: Makes a Python 3.13 manylinux2014 wheel, and puts it in the
 ./out directory.
-* make 39|310|311|312|313: These are specific commands to make the
+* make 310|311|312|313: These are specific commands to make the
 corresponding 3.x version in the ./out directory.
 
 The test target here is mainly to validate the image build, it is

--- a/manylinux2014-wheel-build/build.sh
+++ b/manylinux2014-wheel-build/build.sh
@@ -16,7 +16,7 @@ fi
 # not strictly necessary, unless running multiple versions from the shell
 rm -f /tmp/*.whl || true
 
-# Python version, as 39,310,311,312,313. Defaults to 313.
+# Python version, as 310,311,312,313. Defaults to 313.
 # Matches the naming in /opt/python/
 PYVER=${1:-313}
 PYBIN=$(echo /opt/python/cp${PYVER}-cp${PYVER}/bin)

--- a/manylinux_2_28-wheel-build/Makefile
+++ b/manylinux_2_28-wheel-build/Makefile
@@ -20,8 +20,6 @@ wheel:
 	-[ ! -d out ] && mkdir out
 	docker run --rm -v $(ROOT):/Pillow -v `pwd`/out:/output $(IMAGENAME):$(BRANCH) /build.sh $(_PYVER)
 
-39:
-	_PYVER=39 $(MAKE) wheel
 310:
 	_PYVER=310 $(MAKE) wheel
 311:

--- a/manylinux_2_28-wheel-build/README.md
+++ b/manylinux_2_28-wheel-build/README.md
@@ -18,7 +18,7 @@ The Makefile has several new commands:
 
 * make wheel: Makes a Python 3.13 manylinux_2_28 wheel, and puts it in the
 ./out directory.
-* make 39|310|311|312|313: These are specific commands to make the
+* make 310|311|312|313: These are specific commands to make the
 corresponding 3.x version in the ./out directory.
 
 The test target here is mainly to validate the image build, it is

--- a/manylinux_2_28-wheel-build/build.sh
+++ b/manylinux_2_28-wheel-build/build.sh
@@ -16,7 +16,7 @@ fi
 # not strictly necessary, unless running multiple versions from the shell
 rm -f /tmp/*.whl || true
 
-# Python version, as 39,310,311,312,313. Defaults to 313.
+# Python version, as 310,311,312,313. Defaults to 313.
 # Matches the naming in /opt/python/
 PYVER=${1:-313}
 PYBIN=$(echo /opt/python/cp${PYVER}-cp${PYVER}/bin)


### PR DESCRIPTION
As per https://github.com/python-pillow/Pillow/pull/9119, Python 3.9 will not be supported in Pillow 12.0.0.