### PR TITLE
Fixed raqm install on CentOS Stream 9

### DIFF
--- a/centos-stream-9-amd64/Dockerfile
+++ b/centos-stream-9-amd64/Dockerfile
@@ -17,8 +17,8 @@ RUN yum install -y \
     libtiff-devel \
     libwebp-devel \
     make \
-    meson \
     nasm \
+    ninja-build \
     openjpeg2-devel \
     openssl-devel \
     sqlite-devel \
@@ -53,6 +53,7 @@ RUN bash -c "python3.10 -m pip install virtualenv \
 
 COPY depends /depends
 RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python3
+RUN /usr/bin/python3 -m pip install --no-cache-dir meson
 RUN cd /depends \
     && ./install_imagequant.sh \
     && ./install_libavif.sh \


### PR DESCRIPTION
After https://github.com/python-pillow/docker-images/pull/244, raqm is no longer installing on CentOS Stream 9 - https://github.com/python-pillow/docker-images/actions/runs/16642644822/job/47095834600#step:7:379