### PR TITLE
Revert "Build Ghostscript from source" on Arch

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -22,6 +22,7 @@ RUN pacman -Sy --noconfirm \
             extra/openjpeg2 \
             extra/tk \
             gcc \
+            ghostscript \
             git \
             make \
             mesa-libgl \
@@ -39,12 +40,6 @@ ADD depends /depends
 RUN cd /depends \
      && ./install_imagequant.sh \
      && ./install_raqm.sh
-
-RUN wget -q https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10051/ghostscript-10.05.1.tar.gz \
-     && tar -xzf ghostscript-10.05.1.tar.gz \
-     && cd ghostscript-10.05.1 \
-     && CFLAGS="-std=gnu17" ./configure --without-x \
-     && make install
 
 ARG PIP_DISABLE_PIP_VERSION_CHECK=1
 ARG PIP_NO_CACHE_DIR=1


### PR DESCRIPTION
Resolves https://github.com/python-pillow/docker-images/issues/238

https://github.com/python-pillow/docker-images/pull/239 can be reverted, now that https://gitlab.archlinux.org/archlinux/packaging/packages/ghostscript/-/issues/3 has been resolved by https://gitlab.archlinux.org/archlinux/packaging/packages/ghostscript/-/commit/f5e438478a4d1efcfcc1df815fe9ca3ff90475de and released as ghostscript-10.05.1-3.