### PR TITLE
Update FreeType to 2.14.1 in amazon-2

### DIFF
--- a/amazon-2-amd64/Dockerfile
+++ b/amazon-2-amd64/Dockerfile
@@ -4,7 +4,6 @@ RUN yum install -y \
     cmake \
     curl \
     findutils \
-    freetype-devel \
     fribidi-devel \
     gcc \
     gcc-c++ \
@@ -69,6 +68,8 @@ RUN python3.10 -m pip install meson
 RUN ln -s /usr/local/bin/python3.10 /usr/bin/python3
 RUN cd /depends \
     && ./install_openjpeg.sh \
+    && ./download-and-extract.sh freetype-2.14.1 https://raw.githubusercontent.com/python-pillow/pillow-depends/main/freetype-2.14.1.tar.gz \
+    && cd freetype-2.14.1 && ./configure --prefix=/usr && make -j4 install && cd .. \
     && ./install_raqm.sh \
     && ./install_webp.sh
 


### PR DESCRIPTION
The amazon-2 job has started failing - https://github.com/python-pillow/docker-images/actions/runs/18022944730/job/51284314660#step:7:284

>   src/_imagingft.c:1372:13: error: implicit declaration of function ‘FT_Set_Named_Instance’; did you mean ‘FT_Get_Name_Index’? [-Werror=implicit-function-declaration]
>        error = FT_Set_Named_Instance(self->face, instance_index);
>                ^~~~~~~~~~~~~~~~~~~~~
>                FT_Get_Name_Index

This is because it is [using freetype 2.8](https://github.com/python-pillow/docker-images/actions/runs/18022944730/job/51284314660#step:6:60), which we [no longer support](https://github.com/python-pillow/Pillow/pull/9053). libraqm 0.10.2 was previously upgrading freetype to 2.11, but [libraqm 0.10.3](https://github.com/python-pillow/Pillow/pull/9137) switched to [freetype 2.13.3](https://github.com/HOST-Oman/libraqm/pull/195) and started using the FreeType xz archive. So the error in amazon-2 is really a failure to unpack the xz archive - https://github.com/python-pillow/docker-images/actions/runs/18022944730/job/51284314660#step:6:13078
> 3.039 Downloading freetype2 source from https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz
> 25.82 ERROR: Subproject freetype2 is buildable: NO
>
> 25.82 meson.build:46:15: ERROR: failed to unpack archive with error: Unknown archive format '/depends/libraqm-0.10.3/subprojects/packagecache/freetype-2.13.3.tar.xz'

This PR manually installs freetype 2.14.1.