### PR TITLE
Install Gentoo NumPy from wheel, instead of package

### DIFF
--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -27,7 +27,7 @@ RUN emerge --quiet sudo dev-python/virtualenv dev-util/cargo-c dev-build/meson x
 
 # Install dependencies
 RUN USE="jpeg jpeg2k lcms tiff truetype webp xcb zlib" emerge --quiet --onlydeps dev-python/pillow
-RUN emerge --quiet app-text/ghostscript-gpl dev-python/numpy dev-vcs/git
+RUN emerge --quiet app-text/ghostscript-gpl dev-vcs/git
 
 RUN useradd --uid 1001 pillow \
     && chown pillow:pillow /home/pillow
@@ -38,6 +38,7 @@ ARG PIP_NO_CACHE_DIR=1
 RUN virtualenv --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --upgrade pip \
     && /vpy3/bin/pip install pytest-cov pytest-timeout \
+    && /vpy3/bin/pip install numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3
 
 COPY depends /depends


### PR DESCRIPTION
Gentoo has started failing in the main repository - https://github.com/python-pillow/Pillow/actions/runs/25167600528/job/73846171796

If it doesn't resolve itself as suddenly as it appeared, then I find that installing NumPy from pip, instead of using the package, fixes it.