### PR TITLE
Require x11-base/xorg-server 21.1.22 on gentoo

### DIFF
--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -23,7 +23,7 @@ RUN emerge --quiet -uDU @world
 # We deliberately set this quite late on to avoid rebuilding e.g. mesa.
 RUN echo 'VIDEO_CARDS="fbdev dummy"' | cat >> /etc/portage/make.conf
 
-RUN emerge --quiet sudo dev-python/virtualenv dev-util/cargo-c dev-build/meson x11-misc/xvfb-run
+RUN emerge --quiet sudo dev-python/virtualenv dev-util/cargo-c dev-build/meson =x11-base/xorg-server-21.1.22 x11-misc/xvfb-run
 
 # Install dependencies
 RUN USE="jpeg jpeg2k lcms tiff truetype webp xcb zlib" emerge --quiet --onlydeps dev-python/pillow


### PR DESCRIPTION
gentoo has started failing again - https://github.com/python-pillow/docker-images/actions/runs/28203043693/job/83547192038#step:6:3701
```
#16 5.132 The following USE changes are necessary to proceed:
#16 5.132  (see "package.use" in the portage(5) man page for more details)
#16 5.132 # required by x11-misc/xvfb-run-21.1.15.2::gentoo
#16 5.132 # required by x11-misc/xvfb-run (argument)
#16 5.132 =x11-base/xorg-server-21.1.22 xvfb
```