### PR TITLE
Update Python to 3.11 in CentOS Stream 9

### DIFF
--- a/centos-stream-9-amd64/Dockerfile
+++ b/centos-stream-9-amd64/Dockerfile
@@ -33,26 +33,26 @@ RUN yum install -y \
 
 RUN useradd --uid 1001 pillow
 
-RUN wget --no-verbose https://www.python.org/ftp/python/3.10.18/Python-3.10.18.tgz \
-    && tar xzf Python-3.10.18.tgz \
-    && cd Python-3.10.18 \
+RUN wget --no-verbose https://www.python.org/ftp/python/3.11.15/Python-3.11.15.tgz \
+    && tar xzf Python-3.11.15.tgz \
+    && cd Python-3.11.15 \
     && ./configure \
     && make altinstall \
     && cd .. \
-    && rm -r Python-3.10.18 Python-3.10.18.tgz
+    && rm -r Python-3.11.15 Python-3.11.15.tgz
 
 ARG PIP_DISABLE_PIP_VERSION_CHECK=1
 ARG PIP_NO_CACHE_DIR=1
 
-RUN bash -c "python3.10 -m pip install virtualenv \
-    && python3.10 -m virtualenv --system-site-packages /vpy3 \
+RUN bash -c "python3.11 -m pip install virtualenv \
+    && python3.11 -m virtualenv --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --upgrade pip \
     && /vpy3/bin/pip install olefile pytest pytest-cov pytest-timeout \
     && /vpy3/bin/pip install numpy --only-binary=:all: || true \
     && chown -R pillow:pillow /vpy3"
 
 COPY depends /depends
-RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python3
+RUN ln -sf /usr/local/bin/python3.11 /usr/bin/python3
 RUN /usr/bin/python3 -m pip install --no-cache-dir meson
 RUN cd /depends \
     && ./install_imagequant.sh \


### PR DESCRIPTION
Since Python 3.10 EOL is approaching in [October 2026](https://peps.python.org/pep-0619/), this upgrades CentOS Stream 9 to Python 3.11.