### PR TITLE
Revert "Require x11-base/xorg-server 21.1.22"

### DIFF
--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -23,7 +23,7 @@ RUN emerge --quiet -uDU @world
 # We deliberately set this quite late on to avoid rebuilding e.g. mesa.
 RUN echo 'VIDEO_CARDS="fbdev dummy"' | cat >> /etc/portage/make.conf
 
-RUN emerge --quiet sudo dev-python/virtualenv dev-util/cargo-c dev-build/meson =x11-base/xorg-server-21.1.22 x11-misc/xvfb-run
+RUN emerge --quiet sudo dev-python/virtualenv dev-util/cargo-c dev-build/meson x11-misc/xvfb-run
 
 # Install dependencies
 RUN USE="jpeg jpeg2k lcms tiff truetype webp xcb zlib" emerge --quiet --onlydeps dev-python/pillow


### PR DESCRIPTION
Revert https://github.com/python-pillow/docker-images/pull/273

Gentoo has started failing with https://github.com/python-pillow/docker-images/actions/runs/29620459703/job/88014328805#step:6:564
> emerge: there are no ebuilds to satisfy "=x11-base/xorg-server-21.1.22".