### PR TITLE
Skip push-valgrind job if not pushed to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
     needs: test-valgrind
     runs-on: ubuntu-latest
     if: "github.event_name == 'push'
-                       && github.ref == 'refs/heads/main'"
+        && github.ref == 'refs/heads/main'"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,8 @@ jobs:
     name: Push ubuntu-24.04-noble-amd64-valgrind
     needs: test-valgrind
     runs-on: ubuntu-latest
+    if: "github.event_name == 'push'
+                       && github.ref == 'refs/heads/main'"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -231,9 +233,7 @@ jobs:
           docker images
 
       - name: Push image
-        if: "steps.build.outputs.logged_in == 'true'
-                           && github.event_name == 'push'
-                           && github.ref == 'refs/heads/main'"
+        if: "steps.build.outputs.logged_in == 'true'"
         run: make push-ubuntu-24.04-noble-amd64-valgrind BRANCH=main
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
In https://github.com/python-pillow/docker-images/actions/runs/29622363010/job/88024277059?pr=277, the 'Push ubuntu-24.04-noble-amd64-valgrind' job runs, but skips the 'Push image' step is skipped.

Without that step, there is no point to the job, so let's skip it if this is not a push to main.